### PR TITLE
[Feature] Add daily increments to Telegram updates

### DIFF
--- a/covid19-stats/src/main/java/org/covid19/Covid19Stats.java
+++ b/covid19-stats/src/main/java/org/covid19/Covid19Stats.java
@@ -113,19 +113,6 @@ public class Covid19Stats {
                                 .withKeySerde(stringSerde)
                                 .withValueSerde(statewiseDeltaSerde))
                 .toStream()
-                .peek((key, value) -> {
-                    try {
-                        // strategic delay to allow the other topology to process
-                        // records before this topology completes. This allows
-                        // the statewise daily incremental stats to be calculated before
-                        // the statewise delta stats are calculated. The consumer listening
-                        // on the statewise-delta-stats will be triggered after daily stats have
-                        // been updated in the KTable.
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        // ignore
-                    }
-                })
                 .to("statewise-delta-stats", Produced.with(stringSerde, statewiseDeltaSerde));
 
 

--- a/covid19-telegram-bot/src/main/java/org/covid19/Covid19TelegramApp.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/Covid19TelegramApp.java
@@ -164,6 +164,17 @@ public class Covid19TelegramApp {
 
                 List<StatewiseStats> stats = new ArrayList<>();
                 List<StatewiseDelta> dailyIncrements = new ArrayList<>();
+                try {
+                    // strategic delay to allow the other topology to process
+                    // records before this topology completes. This allows
+                    // the statewise daily incremental stats to be calculated before
+                    // the statewise delta stats are calculated. The consumer listening
+                    // on the statewise-delta-stats will be triggered after daily stats have
+                    // been updated in the KTable.
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
                 readyToSend.forEach(statewiseDelta -> {
                     stats.add(statewiseStore.get(statewiseDelta.getState()));
                     dailyIncrements.add(dailyStatewiseStore.get(statewiseDelta.getState()));

--- a/covid19-telegram-bot/src/main/java/org/covid19/Utils.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/Utils.java
@@ -2,11 +2,13 @@ package org.covid19;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.LinkedList;
 import java.util.List;
 
 public class Utils {
-    public static <A, B> List<Pair<A, B>> zip(List<A> listA, List<B> listB) {
+    static <A, B> List<Pair<A, B>> zip(List<A> listA, List<B> listB) {
         if (listA.size() != listB.size()) {
             throw new IllegalArgumentException("Lists must have same size");
         }
@@ -17,5 +19,10 @@ public class Utils {
             pairList.add(Pair.of(listA.get(index), listB.get(index)));
         }
         return pairList;
+    }
+
+    static String friendlyTime(String lastUpdated) {
+        final LocalDateTime localDateTime = LocalDateTime.parse(lastUpdated, DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss"));
+        return localDateTime.format(DateTimeFormatter.ofPattern("MMMM dd, hh:mm a"));
     }
 }

--- a/covid19-telegram-bot/src/main/java/org/covid19/Utils.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/Utils.java
@@ -1,0 +1,21 @@
+package org.covid19;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class Utils {
+    public static <A, B> List<Pair<A, B>> zip(List<A> listA, List<B> listB) {
+        if (listA.size() != listB.size()) {
+            throw new IllegalArgumentException("Lists must have same size");
+        }
+
+        List<Pair<A, B>> pairList = new LinkedList<>();
+
+        for (int index = 0; index < listA.size(); index++) {
+            pairList.add(Pair.of(listA.get(index), listB.get(index)));
+        }
+        return pairList;
+    }
+}

--- a/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
+++ b/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
@@ -1,6 +1,5 @@
 package org.covid19;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -8,7 +7,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.covid19.Utils.zip;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AlertTextTests {
@@ -66,9 +64,9 @@ public class AlertTextTests {
                 "</pre>\n";
         AtomicReference<String> actualSummaryBlock = new AtomicReference<>("");
 
-        List<StatewiseStats> stats = Collections.singletonList(new StatewiseStats("0", "5341", "157", "455", "Total", "TT", ""));
-        List<StatewiseDelta> increments = Collections.singletonList(new StatewiseDelta(9L, 4L, 15L, 0L, 0L, 0L, "", "Total"));
-        Covid19TelegramApp.buildSummaryAlertBlock(actualSummaryBlock, zip(stats, increments));
+        List<StatewiseDelta> deltas = Collections.singletonList(new StatewiseDelta(9L, 4L, 15L, 455L, 157L, 5341L, "", "Total"));
+        List<StatewiseDelta> dailies = Collections.singletonList(new StatewiseDelta(9L, 4L, 15L, 0L, 0L, 0L, "", "Total"));
+        Covid19TelegramApp.buildSummaryAlertBlock(actualSummaryBlock, deltas, dailies);
 
         assertEquals(expectedSummaryBlock, actualSummaryBlock.get(), "Summary block is not structured correctly!");
     }
@@ -101,19 +99,18 @@ public class AlertTextTests {
                 "Deaths     : (↑3) 157\n" +
                 "</pre>\n";
 
-        List<StatewiseStats> stats = Arrays.asList(
-                new StatewiseStats("0", "28", "0", "0", "Assam", "AS", ""),
-                new StatewiseStats("0", "27", "2", "1", "Himachal Pradesh", "HP", ""),
-                new StatewiseStats("0", "5341", "157", "455", "Total", "TT", ""));
-        List<StatewiseDelta> increments = Arrays.asList(
+        String lastUpdated = "April 08, 12:04 AM";
+
+        List<StatewiseDelta> dailies = Arrays.asList(
                 new StatewiseDelta(0L, 0L, 1L, 0L, 0L, 0L, "08/04/2020 23:41:35", "Assam"),
                 new StatewiseDelta(0L, 0L, 9L, 0L, 0L, 0L, "08/04/2020 00:04:28", "Himachal Pradesh"),
                 new StatewiseDelta(8L, 3L, 31L, 0L, 0L, 0L, "08/04/2020 00:04:28", "Total"));
         List<StatewiseDelta> deltas = Arrays.asList(
-                new StatewiseDelta(0L, 0L, 1L, 0L, 0L, 0L, "08/04/2020 23:41:35", "Assam"),
-                new StatewiseDelta(0L, 0L, 9L, 0L, 0L, 0L, "08/04/2020 00:04:28", "Himachal Pradesh"));
+                new StatewiseDelta(0L, 0L, 1L, 0L, 0L, 28L, "08/04/2020 23:41:35", "Assam"),
+                new StatewiseDelta(0L, 0L, 9L, 1L, 2L, 27L, "08/04/2020 00:04:28", "Himachal Pradesh"),
+                new StatewiseDelta(0L, 0L, 9L, 455L, 157L, 5341L, "08/04/2020 00:04:28", "Total"));
 
-        final String actualFinalAlert = Covid19TelegramApp.buildStatewiseAlertText(zip(stats, increments), deltas);
+        final String actualFinalAlert = Covid19TelegramApp.buildStatewiseAlertText(lastUpdated, deltas, dailies);
 
         assertEquals(expectedFinalAlert, actualFinalAlert, "Summary block is not structured correctly!");
     }

--- a/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
+++ b/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
@@ -1,5 +1,6 @@
 package org.covid19;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -7,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.covid19.Utils.zip;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AlertTextTests {
@@ -58,14 +60,15 @@ public class AlertTextTests {
     void summaryAlertBlock() {
         final String expectedSummaryBlock = "\n<b>Total</b>\n" +
                 "<pre>\n" +
-                "Total cases: 5341\n" +
-                "Recovered  : 455\n" +
-                "Deaths     : 157\n" +
+                "Total cases: (↑15) 5341\n" +
+                "Recovered  : (↑9) 455\n" +
+                "Deaths     : (↑4) 157\n" +
                 "</pre>\n";
         AtomicReference<String> actualSummaryBlock = new AtomicReference<>("");
 
         List<StatewiseStats> stats = Collections.singletonList(new StatewiseStats("0", "5341", "157", "455", "Total", "TT", ""));
-        Covid19TelegramApp.buildSummaryAlertBlock(actualSummaryBlock, stats);
+        List<StatewiseDelta> increments = Collections.singletonList(new StatewiseDelta(9L, 4L, 15L, 0L, 0L, 0L, "", "Total"));
+        Covid19TelegramApp.buildSummaryAlertBlock(actualSummaryBlock, zip(stats, increments));
 
         assertEquals(expectedSummaryBlock, actualSummaryBlock.get(), "Summary block is not structured correctly!");
     }
@@ -79,34 +82,38 @@ public class AlertTextTests {
                 "\n" +
                 "<b>Assam</b>\n" +
                 "<pre>\n" +
-                "Total cases: 28\n" +
-                "Recovered  : 0\n" +
-                "Deaths     : 0\n" +
+                "Total cases: (↑1) 28\n" +
+                "Recovered  : (↑0) 0\n" +
+                "Deaths     : (↑0) 0\n" +
                 "</pre>\n" +
                 "\n" +
                 "<b>Himachal Pradesh</b>\n" +
                 "<pre>\n" +
-                "Total cases: 27\n" +
-                "Recovered  : 1\n" +
-                "Deaths     : 2\n" +
+                "Total cases: (↑9) 27\n" +
+                "Recovered  : (↑0) 1\n" +
+                "Deaths     : (↑0) 2\n" +
                 "</pre>\n" +
                 "\n" +
                 "<b>Total</b>\n" +
                 "<pre>\n" +
-                "Total cases: 5341\n" +
-                "Recovered  : 455\n" +
-                "Deaths     : 157\n" +
+                "Total cases: (↑31) 5341\n" +
+                "Recovered  : (↑8) 455\n" +
+                "Deaths     : (↑3) 157\n" +
                 "</pre>\n";
 
         List<StatewiseStats> stats = Arrays.asList(
                 new StatewiseStats("0", "28", "0", "0", "Assam", "AS", ""),
                 new StatewiseStats("0", "27", "2", "1", "Himachal Pradesh", "HP", ""),
                 new StatewiseStats("0", "5341", "157", "455", "Total", "TT", ""));
+        List<StatewiseDelta> increments = Arrays.asList(
+                new StatewiseDelta(0L, 0L, 1L, 0L, 0L, 0L, "08/04/2020 23:41:35", "Assam"),
+                new StatewiseDelta(0L, 0L, 9L, 0L, 0L, 0L, "08/04/2020 00:04:28", "Himachal Pradesh"),
+                new StatewiseDelta(8L, 3L, 31L, 0L, 0L, 0L, "08/04/2020 00:04:28", "Total"));
         List<StatewiseDelta> deltas = Arrays.asList(
                 new StatewiseDelta(0L, 0L, 1L, 0L, 0L, 0L, "08/04/2020 23:41:35", "Assam"),
                 new StatewiseDelta(0L, 0L, 9L, 0L, 0L, 0L, "08/04/2020 00:04:28", "Himachal Pradesh"));
 
-        final String actualFinalAlert = Covid19TelegramApp.buildStatewiseAlertText(stats, deltas);
+        final String actualFinalAlert = Covid19TelegramApp.buildStatewiseAlertText(zip(stats, increments), deltas);
 
         assertEquals(expectedFinalAlert, actualFinalAlert, "Summary block is not structured correctly!");
     }


### PR DESCRIPTION
Adds a new topology to calculate daily statewise increments in 24h windows. These are then accessed via local keystore and included in the Telegram updates.

Sample alert:

_April 10, 01:35 AM_

1 death in Maharashtra
15 recoveries in Rajasthan

**Total**

```
Total cases: (↑809) 6725
Recovered  : (↑55) 635
Deaths     : (↑46) 227
```

**Maharashtra**

```
Total cases: (↑229) 1364
Recovered  : (↑8) 125
Deaths     : (↑25) 98
```

**Rajasthan**

```
Total cases: (↑80) 463
Recovered  : (↑0) 60
Deaths     : (↑0) 3
```