### PR TITLE
Summary updates of all Indian states every 4 hours

### DIFF
--- a/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
@@ -87,7 +87,6 @@ public class KafkaStreamsConfig {
                         LOG.info("Sending telegram alert to {} of patient #{}", userId, patientNumber);
                         sendTelegramAlert(covid19Bot, userId, alertText, null, false);
                     });
-                    // this is now redundant as we store the patientNumber->messageId mapping in Telegram Embedded DB
                     return PatientAndMessage.builder().message(null).patientInfo(patientAndMessage.getPatientInfo()).build();
                 })
                 .filter((patientNumber, patientAndMessage) -> nonNull(patientAndMessage))

--- a/covid19-telegram-bot/src/main/java/org/covid19/StatsAlertConsumerConfig.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/StatsAlertConsumerConfig.java
@@ -5,6 +5,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.springframework.boot.ApplicationRunner;
@@ -19,6 +20,8 @@ import org.springframework.kafka.config.StreamsBuilderFactoryBean;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,19 +30,28 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import lombok.extern.slf4j.Slf4j;
+
 import static org.covid19.TelegramUtils.buildStatewiseAlertText;
 import static org.covid19.TelegramUtils.fireStatewiseTelegramAlert;
 import static org.covid19.Utils.friendlyTime;
+import static org.covid19.Utils.initStateCodes;
 
 @EnableKafka
 @Configuration
+@EnableScheduling
+@Slf4j
 public class StatsAlertConsumerConfig {
-
     private final KafkaProperties kafkaProperties;
     private final Serde<String> stringSerde;
     private final Covid19Bot covid19Bot;
     private ReadOnlyKeyValueStore<String, StatewiseDelta> dailyStatsStore;
     private KafkaListenerEndpointRegistry registry;
+    final static Map<String, String> stateCodes;
+
+    static {
+        stateCodes = initStateCodes();
+    }
 
     public StatsAlertConsumerConfig(KafkaProperties kafkaProperties, Covid19Bot covid19Bot, KafkaListenerEndpointRegistry registry) {
         this.kafkaProperties = kafkaProperties;
@@ -47,6 +59,7 @@ public class StatsAlertConsumerConfig {
         this.registry = registry;
         this.stringSerde = Serdes.String();
     }
+
 
     @Bean
     public Map<String, Object> consumerConfigs() {
@@ -122,5 +135,39 @@ public class StatsAlertConsumerConfig {
         }
         fireStatewiseTelegramAlert(covid19Bot, buildStatewiseAlertText(friendlyTime(lastUpdated), readyToSend, dailyIncrements));
         readyToSend.clear();
+    }
+
+    @Scheduled(cron = "0 20 4,8,12,16,18 * * ?")
+    public void sendSummaryUpdates() {
+        final KeyValueIterator<String, StatewiseDelta> stats = dailyStatsStore.all();
+
+        List<StatewiseDelta> sortedStats = new ArrayList<>();
+        StatewiseDelta total = new StatewiseDelta();
+        stats.forEachRemaining(stat -> sortedStats.add(stat.value));
+        sortedStats.sort((o1, o2) -> (int) (o2.getCurrentConfirmed() - o1.getCurrentConfirmed()));
+
+        String lastUpdated = sortedStats.get(0).getLastUpdatedTime();
+
+        String text = String.format("<i>%s</i>\n\n", friendlyTime(lastUpdated));
+        text = text.concat("Summary of all affected Indian States\n\n");
+        text = text.concat("<pre>\n");
+        text = text.concat("State|  Conf|  Rec.| Died\n");
+        text = text.concat("-------------------------\n");
+        for (StatewiseDelta stat : sortedStats) {
+            if ("Total".equalsIgnoreCase(stat.getState())) {
+                total = stat;
+                continue; // show total at the end
+            }
+            if (stat.getCurrentConfirmed() < 1L && stat.getCurrentRecovered() < 1L && stat.getCurrentDeaths() < 1L) {
+                continue; // skip states with zero stats
+            }
+            text = text.concat(String.format("%-5s|%6s|%6s|%5s\n", stateCodes.get(stat.getState()), stat.getCurrentConfirmed(), stat.getCurrentRecovered(), stat.getCurrentDeaths()));
+        }
+        text = text.concat("-------------------------\n");
+        text = text.concat(String.format("%-5s|%6s|%6s|%5s\n", stateCodes.get(total.getState()), total.getCurrentConfirmed(), total.getCurrentRecovered(), total.getCurrentDeaths()));
+        text = text.concat("</pre>");
+
+        LOG.info("summary text {}", text);
+        fireStatewiseTelegramAlert(covid19Bot, text);
     }
 }

--- a/covid19-telegram-bot/src/main/java/org/covid19/Utils.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/Utils.java
@@ -4,8 +4,10 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 public class Utils {
     static <A, B> List<Pair<A, B>> zip(List<A> listA, List<B> listB) {
@@ -25,4 +27,48 @@ public class Utils {
         final LocalDateTime localDateTime = LocalDateTime.parse(lastUpdated, DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss"));
         return localDateTime.format(DateTimeFormatter.ofPattern("MMMM dd, hh:mm a"));
     }
+
+    static Map<String, String> initStateCodes() {
+        Map<String, String> stateCodes = new HashMap<>();
+        stateCodes.put("Total", "Total");
+        stateCodes.put("Andhra Pradesh", "AP");
+        stateCodes.put("Arunachal Pradesh", "AR");
+        stateCodes.put("Assam", "Assam");
+        stateCodes.put("Bihar", "Bihar");
+        stateCodes.put("Chhattisgarh", "CT");
+        stateCodes.put("Goa", "Goa");
+        stateCodes.put("Gujarat", "Guja");
+        stateCodes.put("Haryana", "HR");
+        stateCodes.put("Himachal Pradesh", "HP");
+        stateCodes.put("Jharkhand", "JH");
+        stateCodes.put("Karnataka", "KA");
+        stateCodes.put("Kerala", "Ker");
+        stateCodes.put("Madhya Pradesh", "MP");
+        stateCodes.put("Maharashtra", "Mah");
+        stateCodes.put("Manipur", "Mani");
+        stateCodes.put("Meghalaya", "Megh");
+        stateCodes.put("Mizoram", "Mizo");
+        stateCodes.put("Nagaland", "Naga");
+        stateCodes.put("Odisha", "Odis");
+        stateCodes.put("Punjab", "Punj");
+        stateCodes.put("Rajasthan", "Raj");
+        stateCodes.put("Sikkim", "Sikk");
+        stateCodes.put("Tamil Nadu", "TN");
+        stateCodes.put("Telangana", "Telg");
+        stateCodes.put("Tripura", "Trip");
+        stateCodes.put("Uttarakhand", "UT");
+        stateCodes.put("Uttar Pradesh", "UP");
+        stateCodes.put("West Bengal", "WB");
+        stateCodes.put("Andaman and Nicobar Islands", "A&N");
+        stateCodes.put("Chandigarh", "CH");
+        stateCodes.put("Dadra and Nagar Haveli", "DNH");
+        stateCodes.put("Daman and Diu", "DD");
+        stateCodes.put("Delhi", "Delhi");
+        stateCodes.put("Jammu and Kashmir", "J&K");
+        stateCodes.put("Ladakh", "LDK");
+        stateCodes.put("Lakshadweep", "LDWP");
+        stateCodes.put("Puducherry", "Pudu");
+        return stateCodes;
+    }
+
 }


### PR DESCRIPTION
Added scheduler that sends summary of current numbers of all Indian states every 4 hours between 9.30 AM - 12 AM IST.

Sample Update:

```
April 13, 01:12 AM

Summary of all affected Indian States

State|  Conf|  Rec.| Died
-------------------------
Mah  |  1982|   217|  149
Delhi|  1154|    28|   24
TN   |  1075|    50|   11
Raj  |   804|   121|   11
MP   |   562|    41|   43
Telg |   531|   103|   16
Guja |   516|    44|   24
UP   |   483|    45|    5
AP   |   420|    12|    7
Ker  |   375|   179|    2
J&K  |   245|     6|    4
KA   |   232|    54|    6
HR   |   195|    44|    3
Punj |   170|    23|   12
WB   |   134|    19|    7
Bihar|    64|    26|    1
Odis |    54|    12|    1
UT   |    35|     5|    0
HP   |    32|    12|    2
Assam|    29|     0|    1
CT   |    25|     9|    0
CH   |    21|     7|    0
JH   |    19|     0|    2
LDK  |    15|    11|    0
A&N  |    11|    10|    0
Goa  |     7|     5|    0
Pudu |     7|     1|    0
Mani |     2|     1|    0
Trip |     2|     0|    0
AR   |     1|     0|    0
DNH  |     1|     0|    0
Mizo |     1|     0|    0
Naga |     1|     0|    0
-------------------------
Total|  9205|  1085|  331
```