### PR TITLE
On-demand statistics with /stats Telegram command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,20 @@ if the update is significant. Currently this means either changes in status or n
 ## Architecture
 
 ![Kafka Streams Architecture](https://i.ibb.co/r2zJFL2/Covid19-India-Alerts-2.png "Covid19 Kafka Streams Architecture")
+
+## On-demand Statistics - Telegram command `/stats`
+
+To get the current statistics of any Indian State or Total, send the command `/stats`.
+
+The bot will reply with an option to choose a region:
+
+![Telegram command /stats choose region](https://i.ibb.co/MPv3jk5/Screenshot-20200413-184036.jpg "Telegram command /stats choose region")
+
+You can select any region or choose `Total` to get cumulative sum of all Indian states. If you choose
+a region, next screen will pop-up asking to choose a state within the region.
+
+![Telegram command /stats choose state](https://i.ibb.co/gPX3tjw/Screenshot-20200413-184138.jpg "Telegram command /stats choose state")
+
+You should get back the cumulative statistics of the chosen state at that point of time.
+
+![Telegram command /stats state summary](https://i.ibb.co/Y2m1Rhk/Screenshot-20200413-184246.jpg "Telegram command /stats state summary")

--- a/covid19-models/src/main/java/org/covid19/UserRequest.java
+++ b/covid19-models/src/main/java/org/covid19/UserRequest.java
@@ -1,0 +1,17 @@
+package org.covid19;
+
+import com.google.gson.annotations.SerializedName;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class UserRequest {
+    private String chatId;
+    private String state;
+}

--- a/covid19-stats/src/main/java/org/covid19/Covid19Stats.java
+++ b/covid19-stats/src/main/java/org/covid19/Covid19Stats.java
@@ -47,6 +47,7 @@ public class Covid19Stats {
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
 //        streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 20 * 1024 * 1024L);
         streamsConfiguration.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, "all");
+        streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 3);
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         // Records should be flushed every 10 seconds. This is less than the default
         // in order to keep this example interactive.

--- a/covid19-telegram-bot/src/main/java/org/covid19/Covid19Bot.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/Covid19Bot.java
@@ -315,6 +315,7 @@ public class Covid19Bot extends AbilityBot implements ApplicationContextAware {
                 .next(northEastIndiaFlow)
                 .next(westIndiaFlow)
                 .next(southIndiaFlow)
+                .next(sendRequestToKafka(isMessage("Total")))
                 .build();
     }
 
@@ -378,6 +379,10 @@ public class Covid19Bot extends AbilityBot implements ApplicationContextAware {
         row = new KeyboardRow();
         row.add("West India");
         row.add("South India");
+        keyboard.add(row);
+
+        row = new KeyboardRow();
+        row.add("Total");
         keyboard.add(row);
 
         markup.setKeyboard(keyboard);

--- a/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
@@ -51,7 +51,8 @@ public class KafkaStreamsConfig {
     public KafkaStreamsConfiguration kStreamsConfig() {
         Map<String, Object> kafkaStreamsProps = new HashMap<>(kafkaProperties.buildStreamsProperties());
         kafkaStreamsProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        kafkaStreamsProps.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+        kafkaStreamsProps.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 3);
+//        kafkaStreamsProps.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
         kafkaStreamsProps.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000);
         kafkaStreamsProps.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
 //        kafkaStreamsProps.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class.getName());

--- a/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
@@ -68,6 +68,14 @@ public class KafkaStreamsConfig {
     }
 
     @Bean
+    public KTable<String, StatewiseDelta> deltaStatsTable(StreamsBuilder streamsBuilder) {
+        return streamsBuilder.table("statewise-delta-stats",
+                Materialized.<String, StatewiseDelta, KeyValueStore<Bytes, byte[]>>as(
+                        Stores.persistentKeyValueStore("statewise-delta-persistent").name())
+                        .withKeySerde(stringSerde).withValueSerde(new StatewiseDeltaSerde()).withCachingDisabled());
+    }
+
+    @Bean
     public KStream<String, PatientAndMessage> individualPatientAlerts(StreamsBuilder kStreamBuilder) {
         final KStream<String, PatientAndMessage> alerts = kStreamBuilder.stream("send-alerts",
                 Consumed.with(stringSerde, patientAndMessageSerde));

--- a/covid19-telegram-bot/src/main/java/org/covid19/UserRequestProducer.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/UserRequestProducer.java
@@ -1,0 +1,45 @@
+package org.covid19;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class UserRequestProducer {
+    private final KafkaProperties kafkaProperties;
+    private final Serde<String> stringSerde;
+
+    public UserRequestProducer(KafkaProperties kafkaProperties) {
+        this.kafkaProperties = kafkaProperties;
+        this.stringSerde = Serdes.String();
+    }
+
+    @Bean
+    public Map<String, Object> producerConfigs() {
+        Map<String, Object> props = new HashMap<>(kafkaProperties.buildProducerProperties());
+
+        props.put(org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, stringSerde.serializer().getClass().getName());
+        props.put(org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaJsonSerializer");
+
+        return props;
+    }
+
+    @Bean
+    public ProducerFactory<String, UserRequest> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerConfigs());
+    }
+
+    @Bean
+    public KafkaTemplate<String, UserRequest> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+}

--- a/covid19-telegram-bot/src/main/resources/application.yml
+++ b/covid19-telegram-bot/src/main/resources/application.yml
@@ -15,3 +15,6 @@ spring:
       bootstrap-servers: "localhost:9092"
       max-poll-records: 100
       auto-offset-reset: earliest
+    producer:
+      client-id: "org.covid19.patient-telegram-bot-user-request-producer"
+      bootstrap-servers: "localhost:9092"


### PR DESCRIPTION
Add new telegram command /stats which takes in an Indian State and responds with the current statistics of that State. Implemented using a regular Kafka producer and consumer.

Signed-off-by: Abhinav Sonkar <xsabhinav@gmail.com>