### PR TITLE
Include doubling rate with every update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ The Telegram Bot is available at https://t.me/covid19_india_alerts_bot
 
 To subscribe, just send the command `/start`. To unsubscribe, send the command `/stop`.
 
+## New Features
+
+1. All updates carry news sources (links to State Govt / ANI tweets).
+2. Updates include `Doubling rate` based on previous day statistics.
+
 Below is an example of an alert sent by the bot:
 
 ![Sample Telegram Bot Alert screenshot](https://i.ibb.co/V3hQLwV/Screenshot-20200402-000351.jpg "Sample Telegram alert")
-![Sample Telegram Bot Statewise Alert screenshot](https://i.ibb.co/RyGHc1t/Screenshot-20200410-115109.jpg "Statewise alert")
+![Sample Telegram Bot Statewise Alert screenshot](https://i.ibb.co/hRw0Qt1/Screenshot-20200423-190044.jpg "Statewise alert")
 
 ## Alert Updates
 
@@ -75,4 +80,10 @@ You should get back the cumulative statistics of the chosen state at that point 
 
 ### Python Importer
 
-The Python script that imports the Covid19India API is available here: https://github.com/xsreality/covid19-patient-importer 
+The Python script that imports the Covid19India API is available here: https://github.com/xsreality/covid19-patient-importer
+
+## Contributing
+
+* Contributions for new ideas and open issues are welcome!
+* Please open a GitHub issue before opening a pull request.
+* For any queries, contact me on Telegram at https://t.me/xsreality  

--- a/covid19-models/src/main/java/org/covid19/StateAndDate.java
+++ b/covid19-models/src/main/java/org/covid19/StateAndDate.java
@@ -1,0 +1,15 @@
+package org.covid19;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class StateAndDate {
+    private String date;
+    private String state;
+}

--- a/covid19-models/src/main/java/org/covid19/StateAndDateSerde.java
+++ b/covid19-models/src/main/java/org/covid19/StateAndDateSerde.java
@@ -1,0 +1,30 @@
+package org.covid19;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.nio.charset.StandardCharsets;
+
+public class StateAndDateSerde extends Serdes.WrapperSerde<StateAndDate> {
+    public StateAndDateSerde() {
+        super(new Serializer<StateAndDate>() {
+            private Gson gson = new GsonBuilder().serializeNulls().create();
+
+            @Override
+            public byte[] serialize(String s, StateAndDate stateAndDate) {
+                return gson.toJson(stateAndDate).getBytes(StandardCharsets.UTF_8);
+            }
+        }, new Deserializer<StateAndDate>() {
+            private Gson gson = new Gson();
+
+            @Override
+            public StateAndDate deserialize(String s, byte[] bytes) {
+                return gson.fromJson(new String(bytes), StateAndDate.class);
+            }
+        });
+    }
+}

--- a/covid19-telegram-bot/src/main/java/org/covid19/Covid19Bot.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/Covid19Bot.java
@@ -527,7 +527,7 @@ public class Covid19Bot extends AbilityBot implements ApplicationContextAware {
     }
 
     private Predicate<Update> isCallbackOrMessage(String msg) {
-        return upd -> (upd.hasMessage() && upd.getMessage().getText().equalsIgnoreCase(msg)) ||
+        return upd -> (upd.hasMessage() && upd.getMessage().hasText() && upd.getMessage().getText().equalsIgnoreCase(msg)) ||
                 (upd.hasCallbackQuery() && upd.getCallbackQuery().getData().equalsIgnoreCase(msg));
     }
 

--- a/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
@@ -53,7 +53,7 @@ public class KafkaStreamsConfig {
     public KafkaStreamsConfiguration kStreamsConfig() {
         Map<String, Object> kafkaStreamsProps = new HashMap<>(kafkaProperties.buildStreamsProperties());
         kafkaStreamsProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        kafkaStreamsProps.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 5);
+        kafkaStreamsProps.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 6);
         kafkaStreamsProps.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000);
         kafkaStreamsProps.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
         return new KafkaStreamsConfiguration(kafkaStreamsProps);
@@ -89,6 +89,14 @@ public class KafkaStreamsConfig {
                 Materialized.<String, UserPrefs, KeyValueStore<Bytes, byte[]>>as(
                         Stores.inMemoryKeyValueStore("user-preferences-inmemory").name())
                         .withKeySerde(Serdes.String()).withValueSerde(new UserPrefsSerde()).withCachingDisabled());
+    }
+
+    @Bean
+    public KTable<String, String> doublingRateTable(StreamsBuilder streamsBuilder) {
+        return streamsBuilder.table("doubling-rate",
+                Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as(
+                        Stores.inMemoryKeyValueStore("doubling-rate-inmemory").name())
+                        .withKeySerde(stringSerde).withValueSerde(stringSerde).withCachingDisabled());
     }
 
     @Bean

--- a/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
@@ -92,11 +92,11 @@ public class KafkaStreamsConfig {
     }
 
     @Bean
-    public KTable<String, String> doublingRateTable(StreamsBuilder streamsBuilder) {
+    public KTable<StateAndDate, String> doublingRateTable(StreamsBuilder streamsBuilder) {
         return streamsBuilder.table("doubling-rate",
-                Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as(
+                Materialized.<StateAndDate, String, KeyValueStore<Bytes, byte[]>>as(
                         Stores.inMemoryKeyValueStore("doubling-rate-inmemory").name())
-                        .withKeySerde(stringSerde).withValueSerde(stringSerde).withCachingDisabled());
+                        .withKeySerde(new StateAndDateSerde()).withValueSerde(stringSerde).withCachingDisabled());
     }
 
     @Bean

--- a/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
@@ -23,7 +23,7 @@ public class StateStoresManager {
     private ReadOnlyKeyValueStore<String, StatewiseDelta> deltaStatsStore;
     private ReadOnlyKeyValueStore<String, UserPrefs> userPrefsStore;
     private ReadOnlyKeyValueStore<String, String> newsSourcesStore;
-    private ReadOnlyKeyValueStore<String, String> doublingRateStore;
+    private ReadOnlyKeyValueStore<StateAndDate, String> doublingRateStore;
 
     private KafkaListenerEndpointRegistry registry;
 
@@ -48,7 +48,7 @@ public class StateStoresManager {
                                     KTable<String, StatewiseDelta> deltaStatsTable,
                                     KTable<String, UserPrefs> userPrefsTable,
                                     KTable<String, String> newsSourcesTable,
-                                    KTable<String, String> doublingRateTable) {
+                                    KTable<StateAndDate, String> doublingRateTable) {
         return args -> {
             latch(fb).await(100, TimeUnit.SECONDS);
             dailyStatsStore = fb.getKafkaStreams().store(dailyStatsTable.queryableStoreName(), QueryableStoreTypes.keyValueStore());
@@ -91,7 +91,7 @@ public class StateStoresManager {
         return newsSourcesStore.get(state);
     }
 
-    public String doublingRateFor(String state) {
-        return doublingRateStore.get(state);
+    public String doublingRateFor(String state, String date) {
+        return doublingRateStore.get(new StateAndDate(date, state));
     }
 }

--- a/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
@@ -23,6 +23,7 @@ public class StateStoresManager {
     private ReadOnlyKeyValueStore<String, StatewiseDelta> deltaStatsStore;
     private ReadOnlyKeyValueStore<String, UserPrefs> userPrefsStore;
     private ReadOnlyKeyValueStore<String, String> newsSourcesStore;
+    private ReadOnlyKeyValueStore<String, String> doublingRateStore;
 
     private KafkaListenerEndpointRegistry registry;
 
@@ -46,13 +47,16 @@ public class StateStoresManager {
                                     KTable<String, StatewiseDelta> dailyStatsTable,
                                     KTable<String, StatewiseDelta> deltaStatsTable,
                                     KTable<String, UserPrefs> userPrefsTable,
-                                    KTable<String, String> newsSourcesTable) {
+                                    KTable<String, String> newsSourcesTable,
+                                    KTable<String, String> doublingRateTable) {
         return args -> {
             latch(fb).await(100, TimeUnit.SECONDS);
             dailyStatsStore = fb.getKafkaStreams().store(dailyStatsTable.queryableStoreName(), QueryableStoreTypes.keyValueStore());
             deltaStatsStore = fb.getKafkaStreams().store(deltaStatsTable.queryableStoreName(), QueryableStoreTypes.keyValueStore());
             userPrefsStore = fb.getKafkaStreams().store(userPrefsTable.queryableStoreName(), QueryableStoreTypes.keyValueStore());
             newsSourcesStore = fb.getKafkaStreams().store(newsSourcesTable.queryableStoreName(), QueryableStoreTypes.keyValueStore());
+            newsSourcesStore = fb.getKafkaStreams().store(newsSourcesTable.queryableStoreName(), QueryableStoreTypes.keyValueStore());
+            doublingRateStore = fb.getKafkaStreams().store(doublingRateTable.queryableStoreName(), QueryableStoreTypes.keyValueStore());
             // start consumers only after state store is ready.
             registry.getListenerContainer("statewiseAlertsConsumer").start();
             registry.getListenerContainer("userRequestsConsumer").start();
@@ -85,5 +89,9 @@ public class StateStoresManager {
 
     public String newsSourceFor(String state) {
         return newsSourcesStore.get(state);
+    }
+
+    public String doublingRateFor(String state) {
+        return doublingRateStore.get(state);
     }
 }

--- a/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
+++ b/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.covid19.TelegramUtils.buildDeltaAlertLine;
@@ -61,15 +63,18 @@ public class AlertTextTests {
     void summaryAlertBlock() {
         final String expectedSummaryBlock = "\n<b>Total</b>\n" +
                 "<pre>\n" +
-                "Total cases: (↑15) 5341\n" +
-                "Recovered  : (↑9) 455\n" +
-                "Deaths     : (↑4) 157\n" +
+                "Total cases  : (↑15) 5341\n" +
+                "Recovered    : (↑9) 455\n" +
+                "Deaths       : (↑4) 157\n" +
+                "Doubling rate: 250 day(s)\n" +
                 "</pre>\n";
         AtomicReference<String> actualSummaryBlock = new AtomicReference<>("");
 
         List<StatewiseDelta> deltas = Collections.singletonList(new StatewiseDelta(9L, 4L, 15L, 455L, 157L, 5341L, "", "Total"));
         List<StatewiseDelta> dailies = Collections.singletonList(new StatewiseDelta(9L, 4L, 15L, 0L, 0L, 0L, "", "Total"));
-        buildSummaryAlertBlock(actualSummaryBlock, deltas, dailies);
+        Map<String, String> doublingRates = new HashMap<>();
+        doublingRates.put("Total", "250");
+        buildSummaryAlertBlock(actualSummaryBlock, deltas, dailies, doublingRates);
 
         assertEquals(expectedSummaryBlock, actualSummaryBlock.get(), "Summary block is not structured correctly!");
     }
@@ -83,23 +88,26 @@ public class AlertTextTests {
                 "\n" +
                 "<b>Assam</b>\n" +
                 "<pre>\n" +
-                "Total cases: (↑1) 28\n" +
-                "Recovered  : (↑0) 0\n" +
-                "Deaths     : (↑0) 0\n" +
+                "Total cases  : (↑1) 28\n" +
+                "Recovered    : (↑0) 0\n" +
+                "Deaths       : (↑0) 0\n" +
+                "Doubling rate: 19.44 day(s)\n" +
                 "</pre>\n" +
                 "\n" +
                 "<b>Himachal Pradesh</b>\n" +
                 "<pre>\n" +
-                "Total cases: (↑9) 27\n" +
-                "Recovered  : (↑0) 1\n" +
-                "Deaths     : (↑0) 2\n" +
+                "Total cases  : (↑9) 27\n" +
+                "Recovered    : (↑0) 1\n" +
+                "Deaths       : (↑0) 2\n" +
+                "Doubling rate: 2.10 day(s)\n" +
                 "</pre>\n" +
                 "\n" +
                 "<b>Total</b>\n" +
                 "<pre>\n" +
-                "Total cases: (↑31) 5341\n" +
-                "Recovered  : (↑8) 455\n" +
-                "Deaths     : (↑3) 157\n" +
+                "Total cases  : (↑31) 5341\n" +
+                "Recovered    : (↑8) 455\n" +
+                "Deaths       : (↑3) 157\n" +
+                "Doubling rate: 116 day(s)\n" +
                 "</pre>\n";
 
         String lastUpdated = "April 08, 12:04 AM";
@@ -112,8 +120,13 @@ public class AlertTextTests {
                 new StatewiseDelta(0L, 0L, 1L, 0L, 0L, 28L, "08/04/2020 23:41:35", "Assam"),
                 new StatewiseDelta(0L, 0L, 9L, 1L, 2L, 27L, "08/04/2020 00:04:28", "Himachal Pradesh"),
                 new StatewiseDelta(0L, 0L, 9L, 455L, 157L, 5341L, "08/04/2020 00:04:28", "Total"));
+        Map<String, String> doublingRates = new HashMap<>();
+        doublingRates.put("Assam", "19.44");
+        doublingRates.put("Himachal Pradesh", "2.10");
+        doublingRates.put("Total", "116");
 
-        final String actualFinalAlert = buildStatewiseAlertText(lastUpdated, deltas, dailies);
+
+        final String actualFinalAlert = buildStatewiseAlertText(lastUpdated, deltas, dailies, doublingRates);
 
         assertEquals(expectedFinalAlert, actualFinalAlert, "Summary block is not structured correctly!");
     }


### PR DESCRIPTION
Closes #19 

Extend the daily incremental stats topology to produce the daily counts to a sink topic. Backlog data added via temporary producer.