### PR TITLE
Include testing data in on-demand updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ To subscribe, just send the command `/start`. To unsubscribe, send the command `
 
 ## New Features
 
-1. All updates carry news sources (links to State Govt / ANI tweets).
-2. Updates include `Doubling rate` based on previous day statistics.
-3. New commands: `/today`, `/summary` and `/total`. See below for more details.
+1. Testing data is included in every on-demand update if available. This includes tests done, positive, negative and positivity rate.
+2. All updates carry news sources (links to State Govt / ANI tweets).
+3. Updates include `Doubling rate` based on previous day statistics.
+4. New commands: `/today`, `/summary` and `/total`. See below for more details.
 
 Below is an example of an alert sent by the bot:
 
@@ -26,16 +27,6 @@ updating the patient information using official and unofficial (social media etc
 tries to capture these updates and sends alerts that links to previous alert sent for the same patient (if any).
 This helps you see the progress a patient makes (like recovered or deceased). Alerts are only sent
 if the update is significant. Currently this means either changes in status or notes.
-
-## Architecture
-
-### Individual Patient Updates
-
-![Kafka Streams Individual Patient Updates](https://i.ibb.co/MPZJjB3/Covid19-India-Alerts-3.png "Kafka Streams Individual Patient Updates")
-
-### Cumulative + Delta + Daily Increase Updates
-
-![Kafka Streams Architecture](https://i.ibb.co/Zd0Ng7F/Covid19-India-Alerts-4.png "Covid19 Kafka Streams Architecture")
 
 ## Telegram Commands
 
@@ -85,7 +76,17 @@ You should get back the cumulative statistics of the chosen state at that point 
 
 ![Telegram command /stats state summary](https://i.ibb.co/q1KdWc2/Screenshot-20200420-191310-01.jpg "Telegram command /stats state summary")
 
-### Python Importer
+## Architecture
+
+### Individual Patient Updates
+
+![Kafka Streams Individual Patient Updates](https://i.ibb.co/MPZJjB3/Covid19-India-Alerts-3.png "Kafka Streams Individual Patient Updates")
+
+### Cumulative + Delta + Daily Increase Updates
+
+![Kafka Streams Architecture](https://i.ibb.co/Zd0Ng7F/Covid19-India-Alerts-4.png "Covid19 Kafka Streams Architecture")
+
+## Python Importer
 
 The Python script that imports the Covid19India API is available here: https://github.com/xsreality/covid19-patient-importer
 

--- a/covid19-models/src/main/java/org/covid19/StatewiseStatsSerde.java
+++ b/covid19-models/src/main/java/org/covid19/StatewiseStatsSerde.java
@@ -15,8 +15,8 @@ public class StatewiseStatsSerde extends Serdes.WrapperSerde<StatewiseStats> {
             private Gson gson = new GsonBuilder().serializeNulls().disableInnerClassSerialization().create();
 
             @Override
-            public byte[] serialize(String s, StatewiseStats StatewiseStats) {
-                return gson.toJson(StatewiseStats).getBytes(StandardCharsets.UTF_8);
+            public byte[] serialize(String s, StatewiseStats statewiseStats) {
+                return gson.toJson(statewiseStats).getBytes(StandardCharsets.UTF_8);
             }
         }, new Deserializer<StatewiseStats>() {
             private Gson gson = new Gson();

--- a/covid19-models/src/main/java/org/covid19/StatewiseTestData.java
+++ b/covid19-models/src/main/java/org/covid19/StatewiseTestData.java
@@ -28,4 +28,6 @@ public class StatewiseTestData {
     @SerializedName("totaltested") private String totalTested;
     private String unconfirmed;
     private String updatedon;
+    @SerializedName("testreportedtoday") private String testReportedToday;
+    @SerializedName("positivereportedtoday") private String positiveReportedToday;
 }

--- a/covid19-models/src/main/java/org/covid19/StatewiseTestData.java
+++ b/covid19-models/src/main/java/org/covid19/StatewiseTestData.java
@@ -1,0 +1,31 @@
+package org.covid19;
+
+import com.google.gson.annotations.SerializedName;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class StatewiseTestData {
+    private String negative;
+    @SerializedName("numcallsstatehelpline") private String numCallsStateHelpline;
+    @SerializedName("numicubeds") private String numIcuBeds;
+    @SerializedName("numisolationbeds") private String numIsolationBeds;
+    @SerializedName("numventilators") private String numVentilators;
+    private String positive;
+    private String source;
+    private String source2;
+    private String state;
+    @SerializedName("testpositivityrate") private String testPositivityRate;
+    @SerializedName("testsperthousand") private String testsPerThousand;
+    @SerializedName("totalpeopleinquarantine") private String tootalPeopleInQuarantine;
+    @SerializedName("totalpeoplereleasedfromquarantine") private String tootalPeopleReleasedFromQuarantine;
+    @SerializedName("totaltested") private String totalTested;
+    private String unconfirmed;
+    private String updatedon;
+}

--- a/covid19-models/src/main/java/org/covid19/StatewiseTestDataSerde.java
+++ b/covid19-models/src/main/java/org/covid19/StatewiseTestDataSerde.java
@@ -1,0 +1,30 @@
+package org.covid19;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.nio.charset.StandardCharsets;
+
+public class StatewiseTestDataSerde extends Serdes.WrapperSerde<StatewiseTestData> {
+    public StatewiseTestDataSerde() {
+        super(new Serializer<StatewiseTestData>() {
+            private Gson gson = new GsonBuilder().serializeNulls().disableInnerClassSerialization().create();
+
+            @Override
+            public byte[] serialize(String s, StatewiseTestData statewiseTestData) {
+                return gson.toJson(statewiseTestData).getBytes(StandardCharsets.UTF_8);
+            }
+        }, new Deserializer<StatewiseTestData>() {
+            private Gson gson = new Gson();
+
+            @Override
+            public StatewiseTestData deserialize(String s, byte[] bytes) {
+                return gson.fromJson(new String(bytes), StatewiseTestData.class);
+            }
+        });
+    }
+}

--- a/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
@@ -53,7 +53,7 @@ public class KafkaStreamsConfig {
     public KafkaStreamsConfiguration kStreamsConfig() {
         Map<String, Object> kafkaStreamsProps = new HashMap<>(kafkaProperties.buildStreamsProperties());
         kafkaStreamsProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        kafkaStreamsProps.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 6);
+        kafkaStreamsProps.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 8);
         kafkaStreamsProps.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000);
         kafkaStreamsProps.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
         return new KafkaStreamsConfiguration(kafkaStreamsProps);
@@ -105,6 +105,14 @@ public class KafkaStreamsConfig {
                 Materialized.<StateAndDate, StatewiseDelta, KeyValueStore<Bytes, byte[]>>as(
                         Stores.inMemoryKeyValueStore("daily-states-count-inmemory").name())
                         .withKeySerde(new StateAndDateSerde()).withValueSerde(new StatewiseDeltaSerde()).withCachingDisabled());
+    }
+
+    @Bean
+    public KTable<StateAndDate, StatewiseTestData> stateTestTable(StreamsBuilder streamsBuilder) {
+        return streamsBuilder.table("statewise-test-data",
+                Materialized.<StateAndDate, StatewiseTestData, KeyValueStore<Bytes, byte[]>>as(
+                        Stores.persistentKeyValueStore("statewise-test-data-persistent").name())
+                        .withKeySerde(new StateAndDateSerde()).withValueSerde(new StatewiseTestDataSerde()).withCachingDisabled());
     }
 
     @Bean

--- a/covid19-telegram-bot/src/main/java/org/covid19/StatsAlertConsumerConfig.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/StatsAlertConsumerConfig.java
@@ -221,14 +221,13 @@ public class StatsAlertConsumerConfig {
 
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy").withZone(of("UTC"));
         String yesterday = dateTimeFormatter.format(Instant.now().minus(1, DAYS));
-        String today = dateTimeFormatter.format(Instant.now());
 
         StatewiseDelta delta = stateStores.deltaStatsForState(request.getState());
         StatewiseDelta daily = stateStores.dailyStatsForState(request.getState());
         String newsSource = stateStores.newsSourceFor(request.getState());
 
         Map<String, StatewiseTestData> testing = new HashMap<>();
-        final StatewiseTestData statewiseTestData = stateStores.testDataFor(request.getState(), today);
+        final StatewiseTestData statewiseTestData = stateStores.latestAvailableTestDataFor(request.getState());
         if (nonNull(statewiseTestData)) {
             LOG.info("Found testing data for {} as {}", request.getState(), statewiseTestData);
             testing.put(request.getState(), statewiseTestData);

--- a/covid19-telegram-bot/src/main/java/org/covid19/TelegramUtils.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/TelegramUtils.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.Long.parseLong;
-import static java.lang.Math.round;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static org.covid19.Utils.friendlyTime;
@@ -152,14 +151,15 @@ public class TelegramUtils {
                 StatewiseTestData testData = testing.get(delta.getState());
                 String positivityRate = calculatePositivityRate(testData);
                 String testingText = String.format("<pre>" +
-                                "Total tested   : %s\n" +
-                                "Positive       : %s\n" +
+                                "Total tested   : (↑%s) %s\n" +
+                                "Positive       : (↑%s) %s\n" +
                                 "Negative       : %s\n" +
                                 "Unconfirmed    : %s\n" +
                                 "Positivity rate: %s%%\n" +
                                 "</pre>\n",
-                        testData.getTotalTested(), testData.getPositive(), testData.getNegative(),
-                        testData.getUnconfirmed(), positivityRate);
+                        testData.getTestReportedToday().isEmpty() ? "?" : testData.getTestReportedToday(), testData.getTotalTested(),
+                        testData.getPositiveReportedToday().isEmpty() ? "?" : testData.getPositiveReportedToday(), testData.getPositive(),
+                        testData.getNegative(), testData.getUnconfirmed(), positivityRate);
                 updateText.accumulateAndGet(testingText, (current, update) -> current + update);
             }
         });

--- a/covid19-telegram-bot/src/main/java/org/covid19/TelegramUtils.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/TelegramUtils.java
@@ -156,10 +156,13 @@ public class TelegramUtils {
                                 "Negative       : %s\n" +
                                 "Unconfirmed    : %s\n" +
                                 "Positivity rate: %s%%\n" +
+                                "Last updated   : %s\n" +
                                 "</pre>\n",
                         testData.getTestReportedToday().isEmpty() ? "?" : testData.getTestReportedToday(), testData.getTotalTested(),
                         testData.getPositiveReportedToday().isEmpty() ? "?" : testData.getPositiveReportedToday(), testData.getPositive(),
-                        testData.getNegative(), testData.getUnconfirmed(), positivityRate);
+                        isNull(testData.getNegative()) ? "N/A" : testData.getNegative(),
+                        isNull(testData.getUnconfirmed()) ? "N/A" : testData.getUnconfirmed(),
+                        positivityRate, testData.getUpdatedon());
                 updateText.accumulateAndGet(testingText, (current, update) -> current + update);
             }
         });

--- a/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
+++ b/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
@@ -91,9 +91,9 @@ public class AlertTextTests {
                 "Deaths       : (↑4) 157\n" +
                 "Doubling rate: 250 days\n" +
                 "</pre>\n" +
-                "<pre>\n" +
-                "Total tested   : 53166\n" +
-                "Positive       : 1621\n" +
+                "<pre>" +
+                "Total tested   : (↑19462) 53166\n" +
+                "Positive       : (↑38) 1621\n" +
                 "Negative       : 51161\n" +
                 "Unconfirmed    : 384\n" +
                 "Positivity rate: 3.05%\n" +
@@ -105,7 +105,7 @@ public class AlertTextTests {
         Map<String, String> doublingRates = new HashMap<>();
         doublingRates.put("Delhi", "250");
         Map<String, StatewiseTestData> testing = new HashMap<>();
-        testing.put("Delhi", new StatewiseTestData("51161", "", "", "", "", "1621", "", "", "Delhi", "", "", "", "", "53166", "384", ""));
+        testing.put("Delhi", new StatewiseTestData("51161", "", "", "", "", "1621", "", "", "Delhi", "", "", "", "", "53166", "384", "", "19462", "38"));
         buildSummaryAlertBlock(actualSummaryBlock, deltas, dailies, testing, doublingRates);
 
         assertEquals(expectedSummaryBlock, actualSummaryBlock.get(), "Summary block is not structured correctly!");

--- a/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
+++ b/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.util.Collections.emptyMap;
 import static org.covid19.TelegramUtils.buildDeltaAlertLine;
 import static org.covid19.TelegramUtils.buildStatewiseAlertText;
 import static org.covid19.TelegramUtils.buildSummaryAlertBlock;
@@ -75,7 +76,37 @@ public class AlertTextTests {
         List<StatewiseDelta> dailies = Collections.singletonList(new StatewiseDelta(9L, 4L, 15L, 0L, 0L, 0L, "", "Total"));
         Map<String, String> doublingRates = new HashMap<>();
         doublingRates.put("Total", "250");
-        buildSummaryAlertBlock(actualSummaryBlock, deltas, dailies, doublingRates);
+        buildSummaryAlertBlock(actualSummaryBlock, deltas, dailies, emptyMap(), doublingRates);
+
+        assertEquals(expectedSummaryBlock, actualSummaryBlock.get(), "Summary block is not structured correctly!");
+    }
+
+    @Test
+    void summaryAlertBlockWithTestingData() {
+        final String expectedSummaryBlock = "\n<b>Delhi</b>\n" +
+                "<pre>\n" +
+                "Total cases  : (↑15) 5341\n" +
+                "Active       : (↑2) 4729\n" +
+                "Recovered    : (↑9) 455\n" +
+                "Deaths       : (↑4) 157\n" +
+                "Doubling rate: 250 days\n" +
+                "</pre>\n" +
+                "<pre>\n" +
+                "Total tested   : 53166\n" +
+                "Positive       : 1621\n" +
+                "Negative       : 51161\n" +
+                "Unconfirmed    : 384\n" +
+                "Positivity rate: 3.05%\n" +
+                "</pre>\n";
+        AtomicReference<String> actualSummaryBlock = new AtomicReference<>("");
+
+        List<StatewiseDelta> deltas = Collections.singletonList(new StatewiseDelta(9L, 4L, 15L, 455L, 157L, 5341L, "", "Delhi"));
+        List<StatewiseDelta> dailies = Collections.singletonList(new StatewiseDelta(9L, 4L, 15L, 0L, 0L, 0L, "", "Delhi"));
+        Map<String, String> doublingRates = new HashMap<>();
+        doublingRates.put("Delhi", "250");
+        Map<String, StatewiseTestData> testing = new HashMap<>();
+        testing.put("Delhi", new StatewiseTestData("51161", "", "", "", "", "1621", "", "", "Delhi", "", "", "", "", "53166", "384", ""));
+        buildSummaryAlertBlock(actualSummaryBlock, deltas, dailies, testing, doublingRates);
 
         assertEquals(expectedSummaryBlock, actualSummaryBlock.get(), "Summary block is not structured correctly!");
     }
@@ -130,7 +161,7 @@ public class AlertTextTests {
         doublingRates.put("Total", "116");
 
 
-        final String actualFinalAlert = buildStatewiseAlertText(lastUpdated, deltas, dailies, doublingRates);
+        final String actualFinalAlert = buildStatewiseAlertText(lastUpdated, deltas, dailies, emptyMap(), doublingRates);
 
         assertEquals(expectedFinalAlert, actualFinalAlert, "Summary block is not structured correctly!");
     }

--- a/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
+++ b/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
@@ -97,6 +97,7 @@ public class AlertTextTests {
                 "Negative       : 51161\n" +
                 "Unconfirmed    : 384\n" +
                 "Positivity rate: 3.05%\n" +
+                "Last updated   : 26/04/2020\n" +
                 "</pre>\n";
         AtomicReference<String> actualSummaryBlock = new AtomicReference<>("");
 
@@ -105,7 +106,7 @@ public class AlertTextTests {
         Map<String, String> doublingRates = new HashMap<>();
         doublingRates.put("Delhi", "250");
         Map<String, StatewiseTestData> testing = new HashMap<>();
-        testing.put("Delhi", new StatewiseTestData("51161", "", "", "", "", "1621", "", "", "Delhi", "", "", "", "", "53166", "384", "", "19462", "38"));
+        testing.put("Delhi", new StatewiseTestData("51161", "", "", "", "", "1621", "", "", "Delhi", "", "", "", "", "53166", "384", "26/04/2020", "19462", "38"));
         buildSummaryAlertBlock(actualSummaryBlock, deltas, dailies, testing, doublingRates);
 
         assertEquals(expectedSummaryBlock, actualSummaryBlock.get(), "Summary block is not structured correctly!");


### PR DESCRIPTION
Closes #23 

Added new topic that holds state and date wise testing data. This is included in on-demand updates (if available).