### PR TITLE
New commands for on-demand charts and graphs

### DIFF
--- a/covid19-models/src/main/java/org/covid19/charts/Chart.java
+++ b/covid19-models/src/main/java/org/covid19/charts/Chart.java
@@ -14,10 +14,10 @@ public class Chart {
     private ChartData data;
     private ChartOption options;
 
-    public Chart(String type, ChartData data) {
+    public Chart(String type, ChartData data, boolean displayLabels) {
         this.type = type;
         this.data = data;
-        PluginDatalabel datalabel = new PluginDatalabel(true, "end", "#ccc", "3", "end");
+        PluginDatalabel datalabel = new PluginDatalabel(displayLabels, "end", "#ccc", "3", "end");
         this.options = new ChartOption(new ChartPlugin(datalabel));
     }
 }

--- a/covid19-models/src/main/java/org/covid19/charts/Chart.java
+++ b/covid19-models/src/main/java/org/covid19/charts/Chart.java
@@ -1,0 +1,23 @@
+package org.covid19.charts;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class Chart {
+    private String type;
+    private ChartData data;
+    private ChartOption options;
+
+    public Chart(String type, ChartData data) {
+        this.type = type;
+        this.data = data;
+        PluginDatalabel datalabel = new PluginDatalabel(true, "end", "#ccc", "3", "end");
+        this.options = new ChartOption(new ChartPlugin(datalabel));
+    }
+}

--- a/covid19-models/src/main/java/org/covid19/charts/ChartData.java
+++ b/covid19-models/src/main/java/org/covid19/charts/ChartData.java
@@ -1,0 +1,17 @@
+package org.covid19.charts;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ChartData {
+    private List<String> labels;
+    private List<ChartDataset> datasets;
+}

--- a/covid19-models/src/main/java/org/covid19/charts/ChartDataset.java
+++ b/covid19-models/src/main/java/org/covid19/charts/ChartDataset.java
@@ -1,0 +1,32 @@
+package org.covid19.charts;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ChartDataset {
+    private String label;
+    private List<Long> data;
+    private Boolean fill;
+    private String borderColor;
+    private String backgroundColor;
+    private String borderWidth;
+    private String barThickness;
+
+    public ChartDataset(String label, List<Long> data, String borderColor) {
+        this.label = label;
+        this.data = data;
+        this.fill = false;
+        this.borderColor = borderColor;
+        this.backgroundColor = this.borderColor;
+        this.borderWidth = "1";
+        this.barThickness = "15";
+    }
+}

--- a/covid19-models/src/main/java/org/covid19/charts/ChartDataset.java
+++ b/covid19-models/src/main/java/org/covid19/charts/ChartDataset.java
@@ -19,6 +19,7 @@ public class ChartDataset {
     private String backgroundColor;
     private String borderWidth;
     private String barThickness;
+    private String pointRadius;
 
     public ChartDataset(String label, List<Long> data, String borderColor) {
         this.label = label;
@@ -28,5 +29,6 @@ public class ChartDataset {
         this.backgroundColor = this.borderColor;
         this.borderWidth = "1";
         this.barThickness = "15";
+        this.pointRadius = "0";
     }
 }

--- a/covid19-models/src/main/java/org/covid19/charts/ChartOption.java
+++ b/covid19-models/src/main/java/org/covid19/charts/ChartOption.java
@@ -1,0 +1,14 @@
+package org.covid19.charts;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ChartOption {
+    private ChartPlugin plugins;
+}

--- a/covid19-models/src/main/java/org/covid19/charts/ChartPlugin.java
+++ b/covid19-models/src/main/java/org/covid19/charts/ChartPlugin.java
@@ -1,0 +1,14 @@
+package org.covid19.charts;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ChartPlugin {
+    private PluginDatalabel datalabels;
+}

--- a/covid19-models/src/main/java/org/covid19/charts/ChartRequest.java
+++ b/covid19-models/src/main/java/org/covid19/charts/ChartRequest.java
@@ -1,0 +1,26 @@
+package org.covid19.charts;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ChartRequest {
+    private String backgroundColor;
+    private String width;
+    private String height;
+    private String format;
+    private Chart chart;
+
+    public ChartRequest(Chart chart) {
+        this.backgroundColor = "transparent";
+        this.width = "500";
+        this.height = "300";
+        this.format = "png";
+        this.chart = chart;
+    }
+}

--- a/covid19-models/src/main/java/org/covid19/charts/ChartRequest.java
+++ b/covid19-models/src/main/java/org/covid19/charts/ChartRequest.java
@@ -18,8 +18,8 @@ public class ChartRequest {
 
     public ChartRequest(Chart chart) {
         this.backgroundColor = "transparent";
-        this.width = "500";
-        this.height = "300";
+        this.width = "750";
+        this.height = "450";
         this.format = "png";
         this.chart = chart;
     }

--- a/covid19-models/src/main/java/org/covid19/charts/PluginDatalabel.java
+++ b/covid19-models/src/main/java/org/covid19/charts/PluginDatalabel.java
@@ -1,0 +1,18 @@
+package org.covid19.charts;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class PluginDatalabel {
+    private Boolean display;
+    private String anchor;
+    private String backgroundColor;
+    private String borderRadius;
+    private String align;
+}

--- a/covid19-telegram-bot/pom.xml
+++ b/covid19-telegram-bot/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>spring-boot-starter</artifactId>
             <version>2.2.6.RELEASE</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springframework/spring-web -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>5.2.5.RELEASE</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka -->
         <dependency>
             <groupId>org.springframework.kafka</groupId>

--- a/covid19-telegram-bot/src/main/java/org/covid19/Covid19Bot.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/Covid19Bot.java
@@ -16,11 +16,14 @@ import org.telegram.abilitybots.api.objects.Ability;
 import org.telegram.abilitybots.api.objects.Reply;
 import org.telegram.abilitybots.api.objects.ReplyFlow;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -212,6 +215,24 @@ public class Covid19Bot extends AbilityBot implements ApplicationContextAware {
                     String message = String.format("User %s (%d) unsubscribed from Covid19 India Patient alerts",
                             translateName(ctx.update().getMessage().getChat()), ctx.user().getId());
                     silent.send(message, CHANNEL_ID);
+                })
+                .build();
+    }
+
+    public Ability image() {
+        return Ability
+                .builder()
+                .name("overview")
+                .privacy(PUBLIC).locality(ALL)
+                .input(0)
+                .action(ctx -> {
+                    byte[] image = this.storesManager.last7DaysOverview();
+                    SendPhoto photo = new SendPhoto().setPhoto("Last 7 days Overview", new ByteArrayInputStream(image)).setChatId(ctx.chatId());
+                    try {
+                        sender.sendPhoto(photo);
+                    } catch (TelegramApiException e) {
+                        e.printStackTrace();
+                    }
                 })
                 .build();
     }

--- a/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
@@ -103,7 +103,7 @@ public class KafkaStreamsConfig {
     public KTable<StateAndDate, StatewiseDelta> dailyCountTable(StreamsBuilder streamsBuilder) {
         return streamsBuilder.table("daily-states-count",
                 Materialized.<StateAndDate, StatewiseDelta, KeyValueStore<Bytes, byte[]>>as(
-                        Stores.inMemoryKeyValueStore("daily-states-count-inmemory").name())
+                        Stores.persistentKeyValueStore("daily-states-count-persistent").name())
                         .withKeySerde(new StateAndDateSerde()).withValueSerde(new StatewiseDeltaSerde()).withCachingDisabled());
     }
 
@@ -113,6 +113,14 @@ public class KafkaStreamsConfig {
                 Materialized.<StateAndDate, StatewiseTestData, KeyValueStore<Bytes, byte[]>>as(
                         Stores.persistentKeyValueStore("statewise-test-data-persistent").name())
                         .withKeySerde(new StateAndDateSerde()).withValueSerde(new StatewiseTestDataSerde()).withCachingDisabled());
+    }
+
+    @Bean
+    public KTable<String, byte[]> visualizationsTable(StreamsBuilder streamsBuilder) {
+        return streamsBuilder.table("visualizations",
+                Materialized.<String, byte[], KeyValueStore<Bytes, byte[]>>as(
+                        Stores.persistentKeyValueStore("visualizations-persistent").name())
+                        .withKeySerde(stringSerde).withValueSerde(Serdes.ByteArray()).withCachingDisabled());
     }
 
     @Bean

--- a/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/KafkaStreamsConfig.java
@@ -14,6 +14,7 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.Stores;
+import org.covid19.bot.Covid19Bot;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,8 +29,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import static org.covid19.TelegramUtils.buildAlertText;
-import static org.covid19.TelegramUtils.sendTelegramAlert;
+import static org.covid19.bot.BotUtils.buildAlertText;
+import static org.covid19.bot.BotUtils.sendTelegramAlert;
 
 @Configuration
 @EnableKafkaStreams

--- a/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
@@ -24,7 +24,9 @@ import lombok.extern.slf4j.Slf4j;
 import static java.time.ZoneId.of;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Objects.isNull;
+import static org.covid19.visualizations.Visualizer.DOUBLING_RATE;
 import static org.covid19.visualizations.Visualizer.LAST_SEVEN_DAYS_OVERVIEW;
+import static org.covid19.visualizations.Visualizer.LAST_TWO_WEEKS_TOTAL;
 
 @Slf4j
 @Configuration
@@ -154,7 +156,15 @@ public class StateStoresManager {
         return testData;
     }
 
-    public byte[] last7DaysOverview() {
+    public byte[] lastWeekOverview() {
         return visualizationsStore.get(LAST_SEVEN_DAYS_OVERVIEW);
+    }
+
+    public byte[] lastTwoWeeksTotal() {
+        return visualizationsStore.get(LAST_TWO_WEEKS_TOTAL);
+    }
+
+    public byte[] doublingRate() {
+        return visualizationsStore.get(DOUBLING_RATE);
     }
 }

--- a/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
@@ -25,8 +25,10 @@ import static java.time.ZoneId.of;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Objects.isNull;
 import static org.covid19.visualizations.Visualizer.DOUBLING_RATE;
+import static org.covid19.visualizations.Visualizer.HISTORY_TREND;
 import static org.covid19.visualizations.Visualizer.LAST_SEVEN_DAYS_OVERVIEW;
 import static org.covid19.visualizations.Visualizer.LAST_TWO_WEEKS_TOTAL;
+import static org.covid19.visualizations.Visualizer.STATES_TREND;
 
 @Slf4j
 @Configuration
@@ -117,6 +119,10 @@ public class StateStoresManager {
         return doublingRateStore.get(new StateAndDate(date, state));
     }
 
+    public KeyValueIterator<StateAndDate, StatewiseDelta> dailyCount() {
+        return dailyCountStore.all();
+    }
+
     public StatewiseDelta dailyCountFor(String state, String date) {
         return dailyCountStore.get(new StateAndDate(date, state));
     }
@@ -166,5 +172,13 @@ public class StateStoresManager {
 
     public byte[] doublingRate() {
         return visualizationsStore.get(DOUBLING_RATE);
+    }
+
+    public byte[] statesTrend() {
+        return visualizationsStore.get(STATES_TREND);
+    }
+
+    public byte[] historyTrend() {
+        return visualizationsStore.get(HISTORY_TREND);
     }
 }

--- a/covid19-telegram-bot/src/main/java/org/covid19/StatsAlertConsumerConfig.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/StatsAlertConsumerConfig.java
@@ -3,6 +3,7 @@ package org.covid19;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.covid19.bot.Covid19Bot;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,12 +36,12 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.CLIENT_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
-import static org.covid19.TelegramUtils.buildStateSummaryAlertText;
-import static org.covid19.TelegramUtils.buildStatewiseAlertText;
-import static org.covid19.TelegramUtils.buildSummaryAlertBlock;
-import static org.covid19.TelegramUtils.fireStatewiseTelegramAlert;
-import static org.covid19.TelegramUtils.sendTelegramAlert;
 import static org.covid19.Utils.friendlyTime;
+import static org.covid19.bot.BotUtils.buildStateSummaryAlertText;
+import static org.covid19.bot.BotUtils.buildStatewiseAlertText;
+import static org.covid19.bot.BotUtils.buildSummaryAlertBlock;
+import static org.covid19.bot.BotUtils.fireStatewiseTelegramAlert;
+import static org.covid19.bot.BotUtils.sendTelegramAlert;
 
 @EnableKafka
 @Configuration

--- a/covid19-telegram-bot/src/main/java/org/covid19/TelegramApp.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/TelegramApp.java
@@ -1,5 +1,6 @@
 package org.covid19;
 
+import org.covid19.bot.Covid19Bot;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
 import org.springframework.beans.factory.annotation.Value;

--- a/covid19-telegram-bot/src/main/java/org/covid19/TelegramApp.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/TelegramApp.java
@@ -7,12 +7,16 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
 import org.telegram.abilitybots.api.db.MapDBContext;
 import org.telegram.telegrambots.ApiContextInitializer;
 import org.telegram.telegrambots.meta.TelegramBotsApi;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
 import java.io.File;
+import java.util.List;
 
 @SpringBootApplication
 public class TelegramApp implements CommandLineRunner {
@@ -57,5 +61,15 @@ public class TelegramApp implements CommandLineRunner {
                 .make();
 
         return new Covid19Bot(telegramBotToken, telegramBotUsername, new MapDBContext(db), telegramCreatorId, telegramChatId);
+    }
+
+    @Bean
+    public RestTemplate restTemplate(List<HttpMessageConverter<?>> messageConverters) {
+        return new RestTemplate(messageConverters);
+    }
+
+    @Bean
+    public ByteArrayHttpMessageConverter byteArrayHttpMessageConverter() {
+        return new ByteArrayHttpMessageConverter();
     }
 }

--- a/covid19-telegram-bot/src/main/java/org/covid19/TelegramUtils.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/TelegramUtils.java
@@ -169,6 +169,9 @@ public class TelegramUtils {
     }
 
     private static String calculatePositivityRate(StatewiseTestData statewiseTestData) {
+        if (statewiseTestData.getPositive().isEmpty() || statewiseTestData.getTotalTested().isEmpty()) {
+            return "0";
+        }
         double positivityRate = 100.0 * parseLong(statewiseTestData.getPositive()) / parseLong(statewiseTestData.getTotalTested());
         return decimalFormatter.format(positivityRate);
     }

--- a/covid19-telegram-bot/src/main/java/org/covid19/Utils.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/Utils.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 public class Utils {
-    static <A, B> List<Pair<A, B>> zip(List<A> listA, List<B> listB) {
+    public static <A, B> List<Pair<A, B>> zip(List<A> listA, List<B> listB) {
         if (listA.size() != listB.size()) {
             throw new IllegalArgumentException("Lists must have same size");
         }
@@ -23,12 +23,12 @@ public class Utils {
         return pairList;
     }
 
-    static String friendlyTime(String lastUpdated) {
+    public static String friendlyTime(String lastUpdated) {
         final LocalDateTime localDateTime = LocalDateTime.parse(lastUpdated, DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss"));
         return localDateTime.format(DateTimeFormatter.ofPattern("MMMM dd, hh:mm a"));
     }
 
-    static Map<String, String> initStateCodes() {
+    public static Map<String, String> initStateCodes() {
         Map<String, String> stateCodes = new HashMap<>();
         stateCodes.put("Total", "Total");
         stateCodes.put("Andhra Pradesh", "AP");

--- a/covid19-telegram-bot/src/main/java/org/covid19/bot/BotUtils.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/bot/BotUtils.java
@@ -1,5 +1,9 @@
-package org.covid19;
+package org.covid19.bot;
 
+import org.covid19.PatientAndMessage;
+import org.covid19.PatientInfo;
+import org.covid19.StatewiseDelta;
+import org.covid19.StatewiseTestData;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Chat;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
@@ -20,7 +24,7 @@ import static org.covid19.Utils.initStateCodes;
 import static org.covid19.Utils.zip;
 
 @Slf4j
-public class TelegramUtils {
+public class BotUtils {
     final static Map<String, String> stateCodes;
 
     static {
@@ -29,7 +33,7 @@ public class TelegramUtils {
 
     private static DecimalFormat decimalFormatter = new DecimalFormat("0.00");
 
-    static String buildAlertText(boolean update, PatientAndMessage patientAndMessage) {
+    public static String buildAlertText(boolean update, PatientAndMessage patientAndMessage) {
         PatientInfo patientInfo = patientAndMessage.getPatientInfo();
         String alertText;
         if (update) {
@@ -84,7 +88,7 @@ public class TelegramUtils {
         return alertText;
     }
 
-    static void sendTelegramAlert(Covid19Bot bot, String chatId, String alertText, Integer replyId, boolean notification) {
+    public static void sendTelegramAlert(Covid19Bot bot, String chatId, String alertText, Integer replyId, boolean notification) {
         try {
             Thread.sleep(50);  // to avoid hitting Telegram rate limits
             SendMessage telegramMessage = new SendMessage()
@@ -101,7 +105,7 @@ public class TelegramUtils {
         }
     }
 
-    static String buildStatewiseAlertText(String lastUpdated, List<StatewiseDelta> deltas, List<StatewiseDelta> dailies, Map<String, StatewiseTestData> testing, Map<String, String> doublingRates) {
+    public static String buildStatewiseAlertText(String lastUpdated, List<StatewiseDelta> deltas, List<StatewiseDelta> dailies, Map<String, StatewiseTestData> testing, Map<String, String> doublingRates) {
         AtomicReference<String> alertText = new AtomicReference<>("");
         deltas.forEach(delta -> buildDeltaAlertLine(alertText, delta));
         if (alertText.get().isEmpty() || "\n".equalsIgnoreCase(alertText.get())) {
@@ -114,7 +118,7 @@ public class TelegramUtils {
         return finalText;
     }
 
-    static void fireStatewiseTelegramAlert(Covid19Bot covid19Bot, String alertText) {
+    public static void fireStatewiseTelegramAlert(Covid19Bot covid19Bot, String alertText) {
         if (isNull(alertText) || alertText.isEmpty()) {
             return; // skip sending alert
         }
@@ -125,9 +129,9 @@ public class TelegramUtils {
         });
     }
 
-    static void buildSummaryAlertBlock(AtomicReference<String> updateText, List<StatewiseDelta> deltas,
-                                       List<StatewiseDelta> dailies, Map<String, StatewiseTestData> testing,
-                                       Map<String, String> doublingRates) {
+    public static void buildSummaryAlertBlock(AtomicReference<String> updateText, List<StatewiseDelta> deltas,
+                                              List<StatewiseDelta> dailies, Map<String, StatewiseTestData> testing,
+                                              Map<String, String> doublingRates) {
         zip(deltas, dailies).forEach(pair -> {
             StatewiseDelta delta = pair.getKey();
             StatewiseDelta daily = pair.getValue();
@@ -176,7 +180,7 @@ public class TelegramUtils {
         return decimalFormatter.format(positivityRate);
     }
 
-    static void buildDeltaAlertLine(AtomicReference<String> updateText, StatewiseDelta delta) {
+    public static void buildDeltaAlertLine(AtomicReference<String> updateText, StatewiseDelta delta) {
         // skip total
         if ("total".equalsIgnoreCase(delta.getState())) {
             return;
@@ -213,7 +217,7 @@ public class TelegramUtils {
         updateText.accumulateAndGet(textLine, (current, update) -> current + update);
     }
 
-    static String buildStateSummaryAlertText(List<StatewiseDelta> sortedStats, String lastUpdated, boolean daily) {
+    public static String buildStateSummaryAlertText(List<StatewiseDelta> sortedStats, String lastUpdated, boolean daily) {
         StatewiseDelta total = new StatewiseDelta();
         String text = String.format("<i>%s</i>\n\n", friendlyTime(lastUpdated));
         text = text.concat("Summary of all affected Indian States\n\n");
@@ -250,7 +254,7 @@ public class TelegramUtils {
         return text;
     }
 
-    static String translateName(Chat chat) {
+    public static String translateName(Chat chat) {
         if (nonNull(chat.getFirstName())) {
             if (nonNull(chat.getLastName())) {
                 return chat.getFirstName() + " " + chat.getLastName();

--- a/covid19-telegram-bot/src/main/java/org/covid19/visualizations/ChartsProducer.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/visualizations/ChartsProducer.java
@@ -1,0 +1,46 @@
+package org.covid19.visualizations;
+
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
+
+@Configuration
+public class ChartsProducer {
+    private final KafkaProperties kafkaProperties;
+    private final Serde<String> stringSerde;
+
+    public ChartsProducer(KafkaProperties kafkaProperties) {
+        this.kafkaProperties = kafkaProperties;
+        this.stringSerde = Serdes.String();
+    }
+
+    @Bean
+    public Map<String, Object> chartsProducerConfigs() {
+        Map<String, Object> props = new HashMap<>(kafkaProperties.buildProducerProperties());
+        props.put(org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, stringSerde.serializer().getClass().getName());
+        props.put(org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        props.put(CLIENT_ID_CONFIG, "org.covid19.patient-telegram-bot-charts-producer");
+        return props;
+    }
+
+    @Bean
+    public ProducerFactory<String, byte[]> chartsProducerFactory() {
+        return new DefaultKafkaProducerFactory<>(chartsProducerConfigs());
+    }
+
+    @Bean
+    public KafkaTemplate<String, byte[]> chartsKafkaTemplate() {
+        return new KafkaTemplate<>(chartsProducerFactory());
+    }
+}

--- a/covid19-telegram-bot/src/main/java/org/covid19/visualizations/VisualizationService.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/visualizations/VisualizationService.java
@@ -28,9 +28,9 @@ public class VisualizationService {
         this.restTemplate = restTemplate;
     }
 
-    public String buildVisualizationRequest(List<String> labels, List<ChartDataset> datasets) {
+    public String buildVisualizationRequest(String type, List<String> labels, List<ChartDataset> datasets) {
         ChartData chartData = new ChartData(labels, datasets);
-        Chart chart = new Chart("bar", chartData);
+        Chart chart = new Chart(type, chartData);
         ChartRequest chartRequest = new ChartRequest(chart);
         return new Gson().toJson(chartRequest, ChartRequest.class);
     }

--- a/covid19-telegram-bot/src/main/java/org/covid19/visualizations/VisualizationService.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/visualizations/VisualizationService.java
@@ -28,9 +28,9 @@ public class VisualizationService {
         this.restTemplate = restTemplate;
     }
 
-    public String buildVisualizationRequest(String type, List<String> labels, List<ChartDataset> datasets) {
+    public String buildVisualizationRequest(String type, List<String> labels, List<ChartDataset> datasets, boolean displayLabels) {
         ChartData chartData = new ChartData(labels, datasets);
-        Chart chart = new Chart(type, chartData);
+        Chart chart = new Chart(type, chartData, displayLabels);
         ChartRequest chartRequest = new ChartRequest(chart);
         return new Gson().toJson(chartRequest, ChartRequest.class);
     }

--- a/covid19-telegram-bot/src/main/java/org/covid19/visualizations/VisualizationService.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/visualizations/VisualizationService.java
@@ -1,0 +1,44 @@
+package org.covid19.visualizations;
+
+import com.google.gson.Gson;
+
+import org.covid19.charts.Chart;
+import org.covid19.charts.ChartData;
+import org.covid19.charts.ChartDataset;
+import org.covid19.charts.ChartRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@Component
+public class VisualizationService {
+
+    @Value("${visualization.url}")
+    private String visualizationUrl;
+
+    private final RestTemplate restTemplate;
+
+    public VisualizationService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public String buildVisualizationRequest(List<String> labels, List<ChartDataset> datasets) {
+        ChartData chartData = new ChartData(labels, datasets);
+        Chart chart = new Chart("bar", chartData);
+        ChartRequest chartRequest = new ChartRequest(chart);
+        return new Gson().toJson(chartRequest, ChartRequest.class);
+    }
+
+    public byte[] buildVisualization(String request) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(APPLICATION_JSON);
+        HttpEntity<String> entity = new HttpEntity<>(request, headers);
+        return restTemplate.postForObject(visualizationUrl, entity, byte[].class);
+    }
+}

--- a/covid19-telegram-bot/src/main/java/org/covid19/visualizations/Visualizer.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/visualizations/Visualizer.java
@@ -1,13 +1,11 @@
 package org.covid19.visualizations;
 
-import com.google.gson.Gson;
-
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.covid19.StateAndDate;
 import org.covid19.StateStoresManager;
 import org.covid19.StatewiseDelta;
-import org.covid19.charts.Chart;
-import org.covid19.charts.ChartData;
 import org.covid19.charts.ChartDataset;
-import org.covid19.charts.ChartRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -15,6 +13,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -24,6 +23,7 @@ import java.util.Map;
 import static java.lang.Long.parseLong;
 import static java.time.ZoneId.of;
 import static java.time.temporal.ChronoUnit.DAYS;
+import static java.util.Arrays.asList;
 import static java.util.Objects.isNull;
 
 @Component
@@ -33,6 +33,10 @@ public class Visualizer {
     private static final String BLUE = "rgb(54, 162, 235)";
     private static final String RED = "rgb(255, 99, 132)";
     private static final String GREEN = "rgb(75, 192, 192)";
+    private static final String ORANGE = "rgb(255, 159, 64)";
+    private static final String YELLOW = "rgb(255, 205, 86)";
+    private static final String PURPLE = "rgb(153, 102, 255)";
+    private static final String GREY = "rgb(201, 203, 207)";
 
     private final StateStoresManager stateStores;
     private final VisualizationService visualizationService;
@@ -44,6 +48,8 @@ public class Visualizer {
     public static final String LAST_SEVEN_DAYS_OVERVIEW = "last7daysoverview";
     public static final String LAST_TWO_WEEKS_TOTAL = "last2weekstotal";
     public static final String DOUBLING_RATE = "doublingrate";
+    public static final String STATES_TREND = "top5statestrend";
+    public static final String HISTORY_TREND = "historytrend";
 
     public Visualizer(StateStoresManager stateStores, VisualizationService visualizationService,
                       KafkaTemplate<String, byte[]> chartsKafkaTemplate) {
@@ -90,7 +96,7 @@ public class Visualizer {
         datasets.add(new ChartDataset("Recovered", dailyRecovered, GREEN));
         datasets.add(new ChartDataset("Deaths", dailyDeceased, BLUE));
 
-        final String dailyChartRequestJson = visualizationService.buildVisualizationRequest("bar", days, datasets);
+        final String dailyChartRequestJson = visualizationService.buildVisualizationRequest("bar", days, datasets, true);
         LOG.info("Request for Visualization service ready: {}", dailyChartRequestJson);
         byte[] dailyImage = visualizationService.buildVisualization(dailyChartRequestJson);
 
@@ -102,13 +108,13 @@ public class Visualizer {
         datasets.add(new ChartDataset("Recovered", totalRecovered, GREEN));
         datasets.add(new ChartDataset("Deaths", totalDeceased, BLUE));
 
-        final String totalChartRequestJson = visualizationService.buildVisualizationRequest("line", days, datasets);
+        final String totalChartRequestJson = visualizationService.buildVisualizationRequest("line", days, datasets, true);
         LOG.info("Request for 2 weeks cumulative chart ready: {}", totalChartRequestJson);
         byte[] cumulativeImage = visualizationService.buildVisualization(totalChartRequestJson);
         chartsKafkaTemplate.send("visualizations", LAST_TWO_WEEKS_TOTAL, cumulativeImage);
     }
 
-    @Scheduled(cron = "0 0 22 * * ?")
+    @Scheduled(cron = "0 2 22 * * ?")
     public void doublingRateChart() {
         LOG.info("Generating doubling rate chart");
         Map<String, String> data = new LinkedHashMap<>();
@@ -135,13 +141,106 @@ public class Visualizer {
 
         datasets.add(new ChartDataset("Doubling Rate", doublingRate, RED));
 
-        ChartData chartData = new ChartData(days, datasets);
-        Chart chart = new Chart("line", chartData);
-        ChartRequest chartRequest = new ChartRequest(chart);
-
-        final String doublingRateRequestJson = new Gson().toJson(chartRequest, ChartRequest.class);
+        final String doublingRateRequestJson = visualizationService.buildVisualizationRequest("line", days, datasets, true);
         LOG.info("Request for 2 weeks cumulative chart ready: {}", doublingRateRequestJson);
         byte[] doublingRateImage = visualizationService.buildVisualization(doublingRateRequestJson);
         chartsKafkaTemplate.send("visualizations", DOUBLING_RATE, doublingRateImage);
+    }
+
+    @Scheduled(cron = "0 3 22 * * ?")
+    public void top5StatesTrend() {
+        LOG.info("Generating top 5 states trend chart");
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy").withZone(of("UTC"));
+        DateTimeFormatter monthDayFormatter = DateTimeFormatter.ofPattern("MMM dd").withZone(of("UTC"));
+
+        List<String> interestingStates = asList("Maharashtra", "Gujarat", "Delhi", "Madhya Pradesh", "Rajasthan");
+        List<String> colors = asList(RED, YELLOW, GREEN, BLUE, ORANGE, PURPLE);
+
+        Map<String, Map<String, Long>> data = new LinkedHashMap<>();
+        for (long deltaDays = 14L; deltaDays >= 1L; deltaDays--) {
+            String day = dateTimeFormatter.format(Instant.now().minus(deltaDays, DAYS));
+            String monthDay = monthDayFormatter.format(Instant.now().minus(deltaDays, DAYS));
+            final KeyValueIterator<StateAndDate, StatewiseDelta> all = stateStores.dailyCount();
+            Map<String, Long> statesData = new LinkedHashMap<>();
+            while (all.hasNext()) {
+                final KeyValue<StateAndDate, StatewiseDelta> next = all.next();
+                StateAndDate stateAndDate = next.key;
+                StatewiseDelta statewiseDelta = next.value;
+                if (!day.equalsIgnoreCase(stateAndDate.getDate())) {
+                    continue;
+                }
+                if (!interestingStates.contains(stateAndDate.getState())) {
+                    continue;
+                }
+                statesData.putIfAbsent(stateAndDate.getState(), statewiseDelta.getCurrentConfirmed());
+            }
+            data.put(monthDay, statesData);
+        }
+
+        // aggregate by state -> [case numbers]
+        Map<String, List<Long>> stateCasesByDate = new LinkedHashMap<>();
+        data.forEach((day, stateCasesData) -> {
+            stateCasesData.forEach((state, total) -> {
+                stateCasesByDate.computeIfAbsent(state, s -> new ArrayList<>()).add(total);
+            });
+        });
+
+        // create datasets
+        List<ChartDataset> datasets = new ArrayList<>();
+        int i = 0;
+        for (Map.Entry<String, List<Long>> entry : stateCasesByDate.entrySet()) {
+            String state = entry.getKey();
+            List<Long> cases = entry.getValue();
+            datasets.add(new ChartDataset(state, cases, colors.get(i++)));
+        }
+
+        final String statesTrendRequestJson = visualizationService.buildVisualizationRequest("line", new ArrayList<>(data.keySet()), datasets, false);
+        LOG.info("Request for 2 weeks cumulative chart ready: {}", statesTrendRequestJson);
+        byte[] statesTrendImage = visualizationService.buildVisualization(statesTrendRequestJson);
+        chartsKafkaTemplate.send("visualizations", STATES_TREND, statesTrendImage);
+    }
+
+    @Scheduled(cron = "0 4 22 * * ?")
+    public void historyTrend() {
+        LOG.info("Generating history trend chart");
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy").withZone(of("UTC"));
+        DateTimeFormatter monthDayFormatter = DateTimeFormatter.ofPattern("MMM dd").withZone(of("UTC"));
+
+        final LocalDate startDate = dateTimeFormatter.parse("30/01/2020", LocalDate::from);// data available from here
+        final LocalDate yesterday = LocalDate.now().minus(1L, DAYS);
+        Map<String, StatewiseDelta> data = new LinkedHashMap<>();
+
+        LocalDate date = startDate;
+        while (date.isBefore(yesterday)) {
+            String fDate = dateTimeFormatter.format(date);
+            String monthDay = monthDayFormatter.format(date);
+            data.put(monthDay, stateStores.dailyCountFor("Total", fDate));
+            date = date.plus(1L, DAYS);
+        }
+
+        List<String> days = new ArrayList<>();
+        List<Long> totalCases = new ArrayList<>();
+        List<Long> recovered = new ArrayList<>();
+        List<Long> deceased = new ArrayList<>();
+        data.forEach((day, delta) -> {
+            if (isNull(delta)) {
+                return;
+            }
+            totalCases.add(delta.getCurrentConfirmed());
+            recovered.add(delta.getCurrentRecovered());
+            deceased.add(delta.getCurrentDeaths());
+            days.add(day);
+        });
+
+        // create datasets
+        List<ChartDataset> datasets = new ArrayList<>(asList(
+                new ChartDataset("Total Cases", totalCases, BLUE),
+                new ChartDataset("Recovered", recovered, GREEN),
+                new ChartDataset("Deceased", deceased, RED)));
+
+        final String historyTrendRequestJson = visualizationService.buildVisualizationRequest("line", days, datasets, false);
+        LOG.info("Request for 2 weeks cumulative chart ready: {}", historyTrendRequestJson);
+        byte[] historyTrendImage = visualizationService.buildVisualization(historyTrendRequestJson);
+        chartsKafkaTemplate.send("visualizations", HISTORY_TREND, historyTrendImage);
     }
 }

--- a/covid19-telegram-bot/src/main/java/org/covid19/visualizations/Visualizer.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/visualizations/Visualizer.java
@@ -1,0 +1,86 @@
+package org.covid19.visualizations;
+
+import org.covid19.StateStoresManager;
+import org.covid19.StatewiseDelta;
+import org.covid19.charts.ChartDataset;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.time.ZoneId.of;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.util.Objects.isNull;
+
+@Component
+public class Visualizer {
+    private static final Logger LOG = LoggerFactory.getLogger(Visualizer.class);
+
+    private static final String BLUE = "rgb(54, 162, 235)";
+    private static final String RED = "rgb(255, 99, 132)";
+    private static final String GREEN = "rgb(75, 192, 192)";
+
+    private final StateStoresManager stateStores;
+    private final VisualizationService visualizationService;
+    private final KafkaTemplate<String, byte[]> chartsKafkaTemplate;
+
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy").withZone(of("UTC"));
+    private final DateTimeFormatter monthDayFormatter = DateTimeFormatter.ofPattern("MMM dd").withZone(of("UTC"));
+
+    public static final String LAST_SEVEN_DAYS_OVERVIEW = "last7daysoverview";
+
+    public Visualizer(StateStoresManager stateStores, VisualizationService visualizationService,
+                      KafkaTemplate<String, byte[]> chartsKafkaTemplate) {
+        this.stateStores = stateStores;
+        this.visualizationService = visualizationService;
+        this.chartsKafkaTemplate = chartsKafkaTemplate;
+    }
+
+    @Scheduled(fixedDelay = 28800000, initialDelay = 60000)
+    public void last7DaysOverview() {
+        LOG.info("Generating visualization for last 7 days overview");
+        Map<String, StatewiseDelta> data = new LinkedHashMap<>();
+        for (long deltaDays = 7L; deltaDays >= 1L; deltaDays--) {
+            String day = dateTimeFormatter.format(Instant.now().minus(deltaDays, DAYS));
+            String monthDay = monthDayFormatter.format(Instant.now().minus(deltaDays, DAYS));
+            StatewiseDelta count = stateStores.dailyCountFor("Total", day);
+            data.put(monthDay, count);
+        }
+
+        List<String> days = new ArrayList<>();
+        List<Long> confirmed = new ArrayList<>();
+        List<Long> recovered = new ArrayList<>();
+        List<Long> deceased = new ArrayList<>();
+        List<ChartDataset> datasets = new ArrayList<>();
+
+        data.forEach((day, delta) -> {
+            if (isNull(delta)) {
+                return;
+            }
+            days.add(day);
+            confirmed.add(delta.getDeltaConfirmed());
+            recovered.add(delta.getDeltaRecovered());
+            deceased.add(delta.getDeltaDeaths());
+            LOG.info("For day {}, count {}", day, delta);
+        });
+
+        datasets.add(new ChartDataset("Confirmed", confirmed, RED));
+        datasets.add(new ChartDataset("Recovered", recovered, GREEN));
+        datasets.add(new ChartDataset("Deaths", deceased, BLUE));
+
+        final String chartRequestJson = visualizationService.buildVisualizationRequest(days, datasets);
+        LOG.info("Request for Visualization service ready: {}", chartRequestJson);
+        byte[] graphImage = visualizationService.buildVisualization(chartRequestJson);
+
+        LOG.info("Producing visualization to Kafka");
+        chartsKafkaTemplate.send("visualizations", LAST_SEVEN_DAYS_OVERVIEW, graphImage);
+    }
+}

--- a/covid19-telegram-bot/src/main/java/org/covid19/visualizations/Visualizer.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/visualizations/Visualizer.java
@@ -1,8 +1,13 @@
 package org.covid19.visualizations;
 
+import com.google.gson.Gson;
+
 import org.covid19.StateStoresManager;
 import org.covid19.StatewiseDelta;
+import org.covid19.charts.Chart;
+import org.covid19.charts.ChartData;
 import org.covid19.charts.ChartDataset;
+import org.covid19.charts.ChartRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -16,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.lang.Long.parseLong;
 import static java.time.ZoneId.of;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Objects.isNull;
@@ -36,6 +42,8 @@ public class Visualizer {
     private final DateTimeFormatter monthDayFormatter = DateTimeFormatter.ofPattern("MMM dd").withZone(of("UTC"));
 
     public static final String LAST_SEVEN_DAYS_OVERVIEW = "last7daysoverview";
+    public static final String LAST_TWO_WEEKS_TOTAL = "last2weekstotal";
+    public static final String DOUBLING_RATE = "doublingrate";
 
     public Visualizer(StateStoresManager stateStores, VisualizationService visualizationService,
                       KafkaTemplate<String, byte[]> chartsKafkaTemplate) {
@@ -44,11 +52,11 @@ public class Visualizer {
         this.chartsKafkaTemplate = chartsKafkaTemplate;
     }
 
-    @Scheduled(fixedDelay = 28800000, initialDelay = 60000)
-    public void last7DaysOverview() {
+    @Scheduled(cron = "0 0 22 * * ?")
+    public void dailyAndTotalCharts() {
         LOG.info("Generating visualization for last 7 days overview");
         Map<String, StatewiseDelta> data = new LinkedHashMap<>();
-        for (long deltaDays = 7L; deltaDays >= 1L; deltaDays--) {
+        for (long deltaDays = 14L; deltaDays >= 1L; deltaDays--) {
             String day = dateTimeFormatter.format(Instant.now().minus(deltaDays, DAYS));
             String monthDay = monthDayFormatter.format(Instant.now().minus(deltaDays, DAYS));
             StatewiseDelta count = stateStores.dailyCountFor("Total", day);
@@ -56,9 +64,12 @@ public class Visualizer {
         }
 
         List<String> days = new ArrayList<>();
-        List<Long> confirmed = new ArrayList<>();
-        List<Long> recovered = new ArrayList<>();
-        List<Long> deceased = new ArrayList<>();
+        List<Long> dailyConfirmed = new ArrayList<>();
+        List<Long> dailyRecovered = new ArrayList<>();
+        List<Long> dailyDeceased = new ArrayList<>();
+        List<Long> totalConfirmed = new ArrayList<>();
+        List<Long> totalRecovered = new ArrayList<>();
+        List<Long> totalDeceased = new ArrayList<>();
         List<ChartDataset> datasets = new ArrayList<>();
 
         data.forEach((day, delta) -> {
@@ -66,21 +77,71 @@ public class Visualizer {
                 return;
             }
             days.add(day);
-            confirmed.add(delta.getDeltaConfirmed());
-            recovered.add(delta.getDeltaRecovered());
-            deceased.add(delta.getDeltaDeaths());
+            dailyConfirmed.add(delta.getDeltaConfirmed());
+            dailyRecovered.add(delta.getDeltaRecovered());
+            dailyDeceased.add(delta.getDeltaDeaths());
+            totalConfirmed.add(delta.getCurrentConfirmed());
+            totalRecovered.add(delta.getCurrentRecovered());
+            totalDeceased.add(delta.getCurrentDeaths());
             LOG.info("For day {}, count {}", day, delta);
         });
 
-        datasets.add(new ChartDataset("Confirmed", confirmed, RED));
-        datasets.add(new ChartDataset("Recovered", recovered, GREEN));
-        datasets.add(new ChartDataset("Deaths", deceased, BLUE));
+        datasets.add(new ChartDataset("Confirmed", dailyConfirmed, RED));
+        datasets.add(new ChartDataset("Recovered", dailyRecovered, GREEN));
+        datasets.add(new ChartDataset("Deaths", dailyDeceased, BLUE));
 
-        final String chartRequestJson = visualizationService.buildVisualizationRequest(days, datasets);
-        LOG.info("Request for Visualization service ready: {}", chartRequestJson);
-        byte[] graphImage = visualizationService.buildVisualization(chartRequestJson);
+        final String dailyChartRequestJson = visualizationService.buildVisualizationRequest("bar", days, datasets);
+        LOG.info("Request for Visualization service ready: {}", dailyChartRequestJson);
+        byte[] dailyImage = visualizationService.buildVisualization(dailyChartRequestJson);
 
         LOG.info("Producing visualization to Kafka");
-        chartsKafkaTemplate.send("visualizations", LAST_SEVEN_DAYS_OVERVIEW, graphImage);
+        chartsKafkaTemplate.send("visualizations", LAST_SEVEN_DAYS_OVERVIEW, dailyImage);
+
+        datasets.clear();
+        datasets.add(new ChartDataset("Confirmed", totalConfirmed, RED));
+        datasets.add(new ChartDataset("Recovered", totalRecovered, GREEN));
+        datasets.add(new ChartDataset("Deaths", totalDeceased, BLUE));
+
+        final String totalChartRequestJson = visualizationService.buildVisualizationRequest("line", days, datasets);
+        LOG.info("Request for 2 weeks cumulative chart ready: {}", totalChartRequestJson);
+        byte[] cumulativeImage = visualizationService.buildVisualization(totalChartRequestJson);
+        chartsKafkaTemplate.send("visualizations", LAST_TWO_WEEKS_TOTAL, cumulativeImage);
+    }
+
+    @Scheduled(cron = "0 0 22 * * ?")
+    public void doublingRateChart() {
+        LOG.info("Generating doubling rate chart");
+        Map<String, String> data = new LinkedHashMap<>();
+        for (long deltaDays = 31L; deltaDays >= 1L; deltaDays--) {
+            String day = dateTimeFormatter.format(Instant.now().minus(deltaDays, DAYS));
+            String monthDay = monthDayFormatter.format(Instant.now().minus(deltaDays, DAYS));
+            String count = stateStores.doublingRateFor("Total", day);
+            data.put(monthDay, count);
+        }
+
+        List<String> days = new ArrayList<>();
+        List<Long> doublingRate = new ArrayList<>();
+        List<ChartDataset> datasets = new ArrayList<>();
+
+        data.forEach((day, rate) -> {
+            if (isNull(rate)) {
+                LOG.error("found null value for {}", day);
+                return;
+            }
+            days.add(day);
+            doublingRate.add(parseLong(rate));
+            LOG.info("For day {}, rate {}", day, rate);
+        });
+
+        datasets.add(new ChartDataset("Doubling Rate", doublingRate, RED));
+
+        ChartData chartData = new ChartData(days, datasets);
+        Chart chart = new Chart("line", chartData);
+        ChartRequest chartRequest = new ChartRequest(chart);
+
+        final String doublingRateRequestJson = new Gson().toJson(chartRequest, ChartRequest.class);
+        LOG.info("Request for 2 weeks cumulative chart ready: {}", doublingRateRequestJson);
+        byte[] doublingRateImage = visualizationService.buildVisualization(doublingRateRequestJson);
+        chartsKafkaTemplate.send("visualizations", DOUBLING_RATE, doublingRateImage);
     }
 }

--- a/covid19-telegram-bot/src/main/resources/application.yml
+++ b/covid19-telegram-bot/src/main/resources/application.yml
@@ -2,6 +2,9 @@ telegram:
   bot.username: covid19_india_alerts_bot
   db.path: /tmp/telegram.db
 
+visualization:
+  url: http://localhost:8403
+
 spring:
   kafka:
     streams:

--- a/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
+++ b/covid19-telegram-bot/src/test/java/org/covid19/AlertTextTests.java
@@ -10,9 +10,9 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyMap;
-import static org.covid19.TelegramUtils.buildDeltaAlertLine;
-import static org.covid19.TelegramUtils.buildStatewiseAlertText;
-import static org.covid19.TelegramUtils.buildSummaryAlertBlock;
+import static org.covid19.bot.BotUtils.buildDeltaAlertLine;
+import static org.covid19.bot.BotUtils.buildStatewiseAlertText;
+import static org.covid19.bot.BotUtils.buildSummaryAlertBlock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AlertTextTests {


### PR DESCRIPTION
Closes #27, #30 

Add first working implementation of chart generation by sending `/charts` command.
