### PR TITLE
Remove patient analyzer topology as relevant data is not available anymore

### DIFF
--- a/covid19-patients-analyzer/src/main/java/org/covid19/Covid19PatientAnalyzer.java
+++ b/covid19-patients-analyzer/src/main/java/org/covid19/Covid19PatientAnalyzer.java
@@ -8,8 +8,6 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.KTable;
-import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
@@ -20,7 +18,6 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Objects;
 import java.util.Properties;
 
 import static java.time.Duration.ofDays;
@@ -31,13 +28,10 @@ import static java.util.Objects.nonNull;
 public class Covid19PatientAnalyzer {
     private static final Logger LOG = LoggerFactory.getLogger(Covid19PatientAnalyzer.class);
 
-    private static final String STATE_STORE_CHANGELOG_POSTED_MESSAGES = "state-store-messages";
     private static String APPLICATION_ID;
     private static String BOOTSTRAP_SERVERS;
     private static String CLIENT_ID;
-    private static String STREAM_POSTED_MESSAGES;
     private static String STREAM_PATIENTS_DATA;
-    private static String STREAM_ALERTS;
     private static String STATE_DIR;
 
     private static final String NEWS_STORE = "news-store";
@@ -48,56 +42,20 @@ public class Covid19PatientAnalyzer {
         final Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
         streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, CLIENT_ID);
-        // Where to find Kafka broker(s).
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, STATE_DIR);
-        // Records should be flushed every 10 seconds. This is less than the default
-        // in order to keep this example interactive.
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000);
 
         final Serde<String> stringSerde = Serdes.String();
         final Serde<PatientInfo> patientInfoSerde = new PatientInfoSerde();
-        final Serde<PatientAndMessage> patientAndMessageSerde = new PatientAndMessageSerde();
 
         final StreamsBuilder builder = new StreamsBuilder();
 
-        final KStream<String, PatientInfo> patients = builder.stream(STREAM_PATIENTS_DATA,
-                Consumed.with(stringSerde, patientInfoSerde));
+        final KStream<String, PatientInfo> patients = builder.stream(STREAM_PATIENTS_DATA, Consumed.with(stringSerde, patientInfoSerde));
 
-        final KTable<String, PatientAndMessage> postedMessages =
-                builder.table(STREAM_POSTED_MESSAGES,
-                        Consumed.with(stringSerde, patientAndMessageSerde),
-                        Materialized.as(STATE_STORE_CHANGELOG_POSTED_MESSAGES));
-
-        final KStream<String, PatientInfo> cleanedPatients = patients
-                // clean out upcoming patients with no useful information yet
-                .filter(Covid19PatientAnalyzer::cleanData);
-
-        cleanedPatients
-                .leftJoin(postedMessages, (latestPatientInfo, patientAndMessage) -> {
-                    if (isHospitalized(latestPatientInfo)) {
-                        // we skip hospitalized patients as they are too many now.
-                        return null;
-                    }
-                    // this is a new patient, not alerted before
-                    if (Objects.isNull(patientAndMessage)) {
-                        LOG.info("Found new patient number (not alerted before {})", latestPatientInfo.getPatientNumber());
-                        return new PatientAndMessage(null, latestPatientInfo);
-                    }
-                    // determine if there is any new information since last update
-                    LOG.info("Re-processing patient number {}", latestPatientInfo.getPatientNumber());
-                    if (isWorthyUpdate(latestPatientInfo, patientAndMessage.getPatientInfo())) {
-                        LOG.info("Found useful updates for patient number {}", latestPatientInfo.getPatientNumber());
-                        return new PatientAndMessage(patientAndMessage.getMessage(), latestPatientInfo);
-                    }
-                    return null;
-                })
-                // filter out unchanged/irrelevant patient information
-                .filter((patientNumber, patientAndMessage) -> nonNull(patientAndMessage))
-                .peek((patientNumber, patientAndMessage) ->
-                        LOG.info("Patient number {} sending to kafka send-alerts topic", patientNumber))
-                .to(STREAM_ALERTS, Produced.with(stringSerde, new PatientAndMessageSerde()));
+        // clean out upcoming patients with no useful information yet
+        final KStream<String, PatientInfo> cleanedPatients = patients.filter(Covid19PatientAnalyzer::cleanData);
 
         // How long we "remember" an event.  During this time, any incoming duplicates of the event
         // will be, well, dropped, thereby de-duplicating the input data.
@@ -109,6 +67,7 @@ public class Covid19PatientAnalyzer {
 
         // retention period must be at least window size -- for this use case, we don't need a longer retention period
         // and thus just use the window size as retention time
+        //noinspection UnnecessaryLocalVariable
         final Duration retentionPeriod = windowSize;
 
         final StoreBuilder<WindowStore<String, Long>> dedupStoreBuilder = Stores.windowStoreBuilder(
@@ -126,6 +85,7 @@ public class Covid19PatientAnalyzer {
                 .selectKey((key, value) -> value.getDetectedState())
                 .mapValues((readOnlyKey, patientInfo) -> bestNewsSource(patientInfo))
                 .filter((key, news) -> nonNull(news))
+                .peek((state, value) -> LOG.info("Found updated news source for state {}: {}", state, value))
                 .to("news-sources", Produced.with(stringSerde, stringSerde));
 
         final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
@@ -162,40 +122,6 @@ public class Covid19PatientAnalyzer {
         return null;
     }
 
-    private static boolean isHospitalized(PatientInfo latestPatientInfo) {
-        return "Hospitalized".equalsIgnoreCase(latestPatientInfo.getCurrentStatus());
-    }
-
-    // determine if the latest patient info has significant changes worth sending alerts again.
-    private static boolean isWorthyUpdate(PatientInfo latestPatientInfo, PatientInfo oldPatientInfo) {
-        if (currentStatusChanged(latestPatientInfo, oldPatientInfo)
-                || moreInfoAvailable(latestPatientInfo, oldPatientInfo)) {
-            return true;
-        }
-        // TODO: Add more conditions here to determine worthy update
-        LOG.info("No useful updates seen for patient number {}", latestPatientInfo.getPatientNumber());
-        return false;
-    }
-
-    private static boolean moreInfoAvailable(PatientInfo latestPatientInfo, PatientInfo oldPatientInfo) {
-        // null check required because notes field was missed earlier
-        if (nonNull(latestPatientInfo.getNotes()) &&
-                !latestPatientInfo.getNotes().equalsIgnoreCase(oldPatientInfo.getNotes())) {
-            LOG.info("Detected change in field notes for patient #{}", latestPatientInfo.getPatientNumber());
-            return true;
-        }
-        if (nonNull(latestPatientInfo.getBackupNotes()) &&
-                !latestPatientInfo.getBackupNotes().equalsIgnoreCase(oldPatientInfo.getBackupNotes())) {
-            LOG.info("Detected change in field backupnotes for patient #{}", latestPatientInfo.getPatientNumber());
-            return true;
-        }
-        return false;
-    }
-
-    private static boolean currentStatusChanged(PatientInfo latestPatientInfo, PatientInfo oldPatientInfo) {
-        return !latestPatientInfo.getCurrentStatus().equalsIgnoreCase(oldPatientInfo.getCurrentStatus());
-    }
-
     private static boolean cleanData(String patientNumber, PatientInfo patientInfo) {
         // filter out entries that don't have a current status set.
         // More rules might be added later.
@@ -219,14 +145,6 @@ public class Covid19PatientAnalyzer {
             LOG.error("Environment variable KAFKA_TOPIC_PATIENTS_DATA must be set!");
             System.exit(-1);
         }
-        if (isNull(System.getenv("KAFKA_TOPIC_POSTED_MESSAGES"))) {
-            LOG.error("Environment variable KAFKA_TOPIC_POSTED_MESSAGES must be set!");
-            System.exit(-1);
-        }
-        if (isNull(System.getenv("KAFKA_TOPIC_ALERTS"))) {
-            LOG.error("Environment variable KAFKA_TOPIC_ALERTS must be set!");
-            System.exit(-1);
-        }
         if (isNull(System.getenv("KAFKA_STATE_DIR"))) {
             LOG.error("Environment variable KAFKA_STATE_DIR must be set!");
             System.exit(-1);
@@ -236,8 +154,6 @@ public class Covid19PatientAnalyzer {
         APPLICATION_ID = System.getenv("KAFKA_APPLICATION_ID");
         CLIENT_ID = APPLICATION_ID + "-client";
         STREAM_PATIENTS_DATA = System.getenv("KAFKA_TOPIC_PATIENTS_DATA");
-        STREAM_POSTED_MESSAGES = System.getenv("KAFKA_TOPIC_POSTED_MESSAGES");
-        STREAM_ALERTS = System.getenv("KAFKA_TOPIC_ALERTS");
         STATE_DIR = System.getenv("KAFKA_STATE_DIR");
     }
 }


### PR DESCRIPTION
Closes #29 

Deprecate patient analyzer topology as relevant data is no longer available from source APIs.