### PR TITLE
Statewise Total Charts

### DIFF
--- a/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
@@ -50,6 +50,7 @@ public class StateStoresManager {
     public static final String STATES_TREND = "top5statestrend";
     public static final String HISTORY_TREND = "historytrend";
     public static final String TESTING_TREND = "testingtotal";
+    public static final String STATEWISE_TOTAL = "-statewisetotal";
 
     private KafkaListenerEndpointRegistry registry;
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy").withZone(of("UTC"));
@@ -247,5 +248,9 @@ public class StateStoresManager {
 
     public byte[] testingTrend() {
         return visualizationsStore.get(TESTING_TREND);
+    }
+
+    public byte[] statewiseTotalChart(String state) {
+        return visualizationsStore.get(state + STATEWISE_TOTAL);
     }
 }

--- a/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/StateStoresManager.java
@@ -145,6 +145,9 @@ public class StateStoresManager {
             if (!state.equalsIgnoreCase(next.key.getState())) {
                 continue;
             }
+            if ("Unknown".equalsIgnoreCase(next.key.getDistrict())) {
+                continue;
+            }
             data.add(next.value);
         }
         return data;

--- a/covid19-telegram-bot/src/main/java/org/covid19/Utils.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/Utils.java
@@ -68,6 +68,7 @@ public class Utils {
         stateCodes.put("Ladakh", "LDK");
         stateCodes.put("Lakshadweep", "LDWP");
         stateCodes.put("Puducherry", "Pudu");
+        stateCodes.put("State Unassigned", "Unass");
         return stateCodes;
     }
 

--- a/covid19-telegram-bot/src/main/java/org/covid19/bot/BotUtils.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/bot/BotUtils.java
@@ -19,11 +19,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.Long.parseLong;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -39,6 +41,18 @@ public class BotUtils {
     static {
         stateCodes = initStateCodes();
     }
+
+    private static final String[] INDIAN_STATES = {
+            "Delhi", "Jammu and Kashmir", "Himachal Pradesh", "Chandigarh",
+            "Haryana", "Punjab", "Rajasthan", "Ladakh",
+            "Chhattisgarh", "Madhya Pradesh", "Uttar Pradesh", "Uttarakhand",
+            "Bihar", "Jharkhand", "Odisha", "West Bengal",
+            "Arunachal Pradesh", "Assam", "Manipur", "Meghalaya",
+            "Mizoram", "Nagaland", "Tripura", "Sikkim",
+            "Goa", "Gujarat", "Maharashtra", "Dadra and Nagar Haveli", "Daman and Diu",
+            "Andhra Pradesh", "Karnataka", "Kerala", "Puducherry",
+            "Tamil Nadu", "Telangana", "Andaman and Nicobar Islands", "Lakshadweep", "State Unassigned"
+    };
 
     private static DecimalFormat decimalFormatter = new DecimalFormat("0.00");
 
@@ -346,7 +360,12 @@ public class BotUtils {
 
         List<StatewiseDelta> sortedStats = new ArrayList<>();
 
-        stats.forEachRemaining(stat -> sortedStats.add(stat.value));
+        stats.forEachRemaining(stat -> {
+            if (asList(INDIAN_STATES).contains(stat.key) || "Total".equalsIgnoreCase(stat.key)) {
+                sortedStats.add(stat.value);
+            }
+        });
+
         if (daily) {
             sortedStats.sort((o1, o2) -> (int) (o2.getDeltaConfirmed() - o1.getDeltaConfirmed()));
         } else {

--- a/covid19-telegram-bot/src/main/java/org/covid19/bot/BotUtils.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/bot/BotUtils.java
@@ -7,10 +7,13 @@ import org.covid19.StateStoresManager;
 import org.covid19.StatewiseDelta;
 import org.covid19.StatewiseTestData;
 import org.covid19.district.DistrictwiseData;
+import org.telegram.telegrambots.meta.api.methods.ParseMode;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
 import org.telegram.telegrambots.meta.api.objects.Chat;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
+import java.io.ByteArrayInputStream;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -107,6 +110,33 @@ public class BotUtils {
 
             bot.execute(telegramMessage);
         } catch (TelegramApiException | InterruptedException e) {
+            LOG.error("Unable to send Telegram alert to user {}, with error {}", chatId, e.getMessage());
+        }
+    }
+
+    public static void sendTelegramAlertWithPhoto(Covid19Bot bot, String chatId, String alertText, Integer replyId, boolean notification, String state, byte[] photo) {
+        try {
+            SendMessage telegramMessage = new SendMessage()
+                    .setChatId(chatId)
+                    .setText(alertText)
+                    .enableHtml(true)
+                    .setReplyToMessageId(replyId);
+
+            telegramMessage = notification ? telegramMessage.enableNotification() : telegramMessage.disableNotification();
+
+            bot.execute(telegramMessage);
+
+            SendPhoto message = new SendPhoto()
+                    .setChatId(chatId)
+                    .setPhoto(state, new ByteArrayInputStream(photo))
+                    .setCaption(state)
+                    .setParseMode(ParseMode.HTML)
+                    .setReplyToMessageId(replyId);
+
+            message = notification ? message.enableNotification() : message.disableNotification();
+
+            bot.execute(message);
+        } catch (TelegramApiException e) {
             LOG.error("Unable to send Telegram alert to user {}, with error {}", chatId, e.getMessage());
         }
     }

--- a/covid19-telegram-bot/src/main/java/org/covid19/bot/Covid19Bot.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/bot/Covid19Bot.java
@@ -44,6 +44,7 @@ import static java.lang.Integer.parseInt;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.Objects.isNull;
 import static org.covid19.bot.BotUtils.buildDistrictSummaryAlertText;
 import static org.covid19.bot.BotUtils.buildDistrictZoneText;
 import static org.covid19.bot.BotUtils.translateName;
@@ -1073,7 +1074,11 @@ public class Covid19Bot extends AbilityBot implements ApplicationContextAware {
             String state = upd.getCallbackQuery().getData();
 
             UserPrefs prefs = storesManager.prefsForUser(chatId);
+            if (isNull(prefs)) {
+                prefs = new UserPrefs(chatId, emptyList(), true);
+            }
             List<String> prefStates = prefs.getMyStates();
+
             if (prefStates.size() >= 3) {
                 EditMessageText msg = new EditMessageText();
                 msg.setChatId(upd.getCallbackQuery().getMessage().getChatId());

--- a/covid19-telegram-bot/src/main/java/org/covid19/request/UserRequestConsumer.java
+++ b/covid19-telegram-bot/src/main/java/org/covid19/request/UserRequestConsumer.java
@@ -40,6 +40,7 @@ import static org.covid19.bot.BotUtils.buildStateSummary;
 import static org.covid19.bot.BotUtils.buildStateSummaryAlertText;
 import static org.covid19.bot.BotUtils.buildSummaryAlertBlock;
 import static org.covid19.bot.BotUtils.sendTelegramAlert;
+import static org.covid19.bot.BotUtils.sendTelegramAlertWithPhoto;
 
 @Configuration
 @Slf4j
@@ -133,7 +134,9 @@ public class UserRequestConsumer {
             alertText.accumulateAndGet(fetchStateNewsSource(testing.get(request.getState())), (current, update) -> current + "\n\nTesting data source: " + update);
         }
 
-        sendTelegramAlert(covid19Bot, request.getChatId(), alertText.get(), null, true);
+        byte[] stateTotalChart = stateStores.statewiseTotalChart(request.getState());
+
+        sendTelegramAlertWithPhoto(covid19Bot, request.getChatId(), alertText.get(), null, true, request.getState(), stateTotalChart);
     }
 
     private String buildSpecificDateSummary(String date) {

--- a/covid19-visualizer/src/main/java/org/covid19/visualizations/VisualizationController.java
+++ b/covid19-visualizer/src/main/java/org/covid19/visualizations/VisualizationController.java
@@ -28,6 +28,8 @@ public class VisualizationController {
             visualizer.testingTrend();
             Thread.sleep(1000);
             visualizer.historyTrend();
+            Thread.sleep(1000);
+            visualizer.statewiseTotal();
         } catch (InterruptedException e) {
             // ignore
         }


### PR DESCRIPTION
Closes #46 

Generate statewise total charts. Include these charts in on-demand request via /stats.